### PR TITLE
New guarantee mechanism

### DIFF
--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -592,7 +592,7 @@ decl_error! {
         AlreadyBonded,
         /// Controller is already paired.
         AlreadyPaired,
-        /// Targets cannot be empty.
+        /// Target is invalid.
         InvalidTarget,
         /// Duplicate index.
         DuplicateIndex,

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -1653,7 +1653,7 @@ impl<T: Trait> Module<T> {
             // 1. Update GuaranteeRel
             for (guarantor, index) in guarantors_with_indexes {
                 let mut records = Self::guarantee_rel(&guarantor, &v_stash);
-                let votes = to_votes(records.get(&(index.clone() as u32)).unwrap().clone());
+                let votes = to_votes(records.get(&index).unwrap().clone());
 
                 // There still has credit for guarantors
                 // we should using `FILO` rule to calculate others
@@ -1673,13 +1673,13 @@ impl<T: Trait> Module<T> {
                             nominations.total -= to_balance(votes - g_real_votes);
                             <Guarantors<T>>::insert(&guarantor, nominations);
                         }
-                        records.insert(index.clone(), g_vote_stakes);
+                        records.insert(index, g_vote_stakes);
                         <GuaranteeRel<T>>::insert(&guarantor, &v_stash, records);
                     }
 
                 // There has no credit for later guarantors
                 } else {
-                    records.remove(&(index.clone() as u32));
+                    records.remove(&index);
                     let is_empty = records.len() == 0;
                     if is_empty {
                         <GuaranteeRel<T>>::remove(&guarantor, &v_stash);

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -1224,10 +1224,8 @@ impl<T: Trait> Module<T> {
         let mut new_guarantors = Self::validators(v_stash).guarantors;
         let mut removed_votes = Zero::zero();
 
-        // 1. Existed edge        
-        let records = Self::guarantee_rel(&g_stash, &v_stash);
-        // 2. Travese from the end of the guarantors
-        for (idx, edge_votes) in records.iter().rev() {
+        // Travese from the end of the records
+        for (idx, edge_votes) in Self::guarantee_rel(&g_stash, &v_stash).iter().rev() {
             if g_votes == Zero::zero() { break }
             // Update votes
             let real_votes = g_votes.min(*edge_votes);

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -929,7 +929,7 @@ decl_module! {
         /// - Both the reads and writes follow a similar pattern.
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(750_000)]
-        fn cancel_guarantee(origin, target: (<T::Lookup as StaticLookup>::Source, BalanceOf<T>)) {
+        fn cut_guarantee(origin, target: (<T::Lookup as StaticLookup>::Source, BalanceOf<T>)) {
             let controller = ensure_signed(origin)?;
             let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
             let g_stash = &ledger.stash;

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -1718,10 +1718,7 @@ impl<T: Trait> Module<T> {
                 let v_total_votes =
                     (v_own_votes + v_guarantors_votes).min(u64::max_value() as u128);
 
-                let mut set_of_guarantors = BTreeSet::new();
-                for guarantor in Self::validators(v_stash).guarantors {
-                    set_of_guarantors.insert(guarantor.clone());
-                }
+                let set_of_guarantors: BTreeSet<T::AccountId> = Self::validators(v_stash).guarantors.drain(..).collect();
 
                 for guarantor in set_of_guarantors {
                     others.push(IndividualExposure {

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -554,10 +554,10 @@ decl_storage! {
                         )
                     },
                     StakerStatus::Guarantor(votes) => {
-                        for (target, votes) in votes {
+                        for (target, vote) in votes {
                             <Module<T>>::guarantee(
                                 T::Origin::from(Some(controller.clone()).into()),
-                                (T::Lookup::unlookup(target.clone()), votes.clone()),
+                                (T::Lookup::unlookup(target.clone()), vote.clone()),
                             ).ok();
                         }
                         Ok(())

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -1189,12 +1189,8 @@ impl<T: Trait> Module<T> {
             for target in nominations.targets {
                 <GuaranteeRel<T>>::remove(&g_stash, &target);
                 let mut validations = Self::validators(&target);
-                let mut new_guarantors = vec![];
-                for value in validations.guarantors {
-                    if &value != g_stash { // chill all guarantors in Validations.guarantors
-                        new_guarantors.push(value.clone());
-                    }
-                }
+                let mut new_guarantors = validations.guarantors;
+                new_guarantors.retain(|value| value != g_stash);
                 validations.guarantors = new_guarantors;
                 <Validators<T>>::insert(&target, validations);
             }

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -1676,14 +1676,15 @@ impl<T: Trait> Module<T> {
 
                 // There has no credit for later guarantors
                 } else {
-                    let mut records = Self::guarantee_rel(&guarantor, &v_stash);
-                    records.remove(&index);
-                    let is_empty = records.len() == 0; // used to remove GuaranteeRel and targets in Nominations
-                    // Remove GuaranteeRel or update it
+                    // Update GuaranteeRel
+                    <GuaranteeRel<T>>::mutate(&guarantor, &v_stash, |records| {
+                        records.remove(&index);
+                    });
+
+                    let is_empty = Self::guarantee_rel(&guarantor, &v_stash).len() == 0; // used to remove GuaranteeRel and targets in Nominations
+                    // Remove it
                     if is_empty {
                         <GuaranteeRel<T>>::remove(&guarantor, &v_stash);
-                    } else {
-                        <GuaranteeRel<T>>::insert(&guarantor, &v_stash, records);
                     }
                     // Update Nominations
                     <Guarantors<T>>::mutate(&guarantor, |nominations| {

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -520,7 +520,7 @@ pub fn bond_validator(acc: u64, val: u64) {
     assert_ok!(Staking::validate(Origin::signed(acc), Perbill::default()));
 }
 
-pub fn bond_guarantor(acc: u64, val: u64, target: Vec<(u64, u64)>) {
+pub fn bond_guarantor(acc: u64, val: u64, targets: Vec<(u64, u64)>) {
     // a = controller
     // a + 1 = stash
     let _ = Balances::make_free_balance_be(&(acc + 1), val);
@@ -530,7 +530,9 @@ pub fn bond_guarantor(acc: u64, val: u64, target: Vec<(u64, u64)>) {
         val,
         RewardDestination::Controller
     ));
-    assert_ok!(Staking::guarantee(Origin::signed(acc), target));
+    for target in targets {
+        assert_ok!(Staking::guarantee(Origin::signed(acc), target));
+    }
 }
 
 pub fn advance_session() {

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -111,8 +111,8 @@ fn basic_setup_works() {
             })
         );
         assert_eq!(Staking::guarantors(101).unwrap().targets, vec![11, 21]);
-        assert_eq!(Staking::guarantee_rel(101, 11), Some(250));
-        assert_eq!(Staking::guarantee_rel(101, 21), Some(250));
+        assert_eq!(Staking::guarantee_rel(101, 11).unwrap().total, 250);
+        assert_eq!(Staking::guarantee_rel(101, 21).unwrap().total, 250);
 
         if cfg!(feature = "equalize") {
             assert_eq!(
@@ -890,8 +890,8 @@ fn double_staking_should_fail() {
             Origin::signed(2),
             vec![(11, arbitrary_value),]
         ));
-        assert_eq!(Staking::guarantee_rel(1, 11), Some(750));
-        assert_eq!(Staking::guarantee_rel(101, 11), Some(250));
+        assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 750);
+        assert_eq!(Staking::guarantee_rel(101, 11).unwrap().total, 250);
         start_era(1, true);
         assert_eq!(
             Staking::ledger(&2),
@@ -3190,7 +3190,7 @@ fn guarantee_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 5), Some(500));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().total, 500);
 
             // After a era, valid stake should updated.
             start_era_with_new_workloads(1, false, 1000, 3000);
@@ -3203,7 +3203,7 @@ fn guarantee_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 5), Some(500));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().total, 500);
 
             assert_eq!(
                 Staking::ledger(&2),
@@ -3226,7 +3226,7 @@ fn guarantee_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 5), Some(2000));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().total, 2000);
 
             // Next era, wr should be outdated
             start_era(2, false);
@@ -3239,7 +3239,7 @@ fn guarantee_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 5), Some(2000));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().total, 2000);
 
             assert_eq!(
                 Staking::ledger(&2),
@@ -3304,7 +3304,7 @@ fn guarantee_order_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 5), Some(1000));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().total, 1000);
 
             assert_eq!(
                 Staking::guarantors(&3),
@@ -3314,7 +3314,7 @@ fn guarantee_order_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(3, 5), Some(1000));
+            assert_eq!(Staking::guarantee_rel(3, 5).unwrap().total, 1000);
 
             assert_eq!(
                 Staking::guarantors(&3),
@@ -3400,7 +3400,7 @@ fn new_era_with_stake_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(1, 11), Some(2000));
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 2000);
 
             assert_eq!(
                 Staking::guarantors(&3),
@@ -3410,7 +3410,7 @@ fn new_era_with_stake_limit_should_work() {
                     suppressed: false
                 })
             );
-            assert_eq!(Staking::guarantee_rel(3, 11), Some(2000));
+            assert_eq!(Staking::guarantee_rel(3, 11).unwrap().total, 2000);
 
             assert_eq!(
                 Staking::guarantors(&3),
@@ -3439,7 +3439,7 @@ fn new_era_with_stake_limit_should_work() {
                     guarantors: vec![1]
                 }
             );
-            assert_eq!(Staking::guarantee_rel(1, 11), Some(1500));
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 1500);
             assert_eq!(
                 Staking::stakers(11),
                 Exposure {

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -3752,8 +3752,20 @@ fn cut_guarantee_should_work() {
             RewardDestination::Controller
         ));
 
+        assert_noop!(
+            Staking::cut_guarantee(Origin::signed(2), (2, 250)),
+            DispatchError::Module {
+                index: 0,
+                error: 4,
+                message: Some("InvalidTarget"),
+            }
+        );
 
-
+        // guarantor's info guarantors should ✅
+        assert_eq!(
+            Staking::guarantors(&1),
+            None
+        );
         assert_ok!(Staking::guarantee(Origin::signed(2), (5, 250)));
         assert_ok!(Staking::guarantee(Origin::signed(2), (5, 250)));
         assert_ok!(Staking::guarantee(Origin::signed(2), (7, 250)));

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -825,7 +825,7 @@ fn guarantors_also_get_slashed() {
                 Staking::guarantee(Origin::signed(2), (20, 250)),
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -834,7 +834,7 @@ fn guarantors_also_get_slashed() {
                 Staking::guarantee(Origin::signed(2), (10, 250)),
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -1892,7 +1892,7 @@ fn switching_roles() {
                 Staking::guarantee(Origin::signed(4), (1, 250)), // 1 is not validator
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -1972,7 +1972,7 @@ fn wrong_vote_is_null() {
                 Staking::guarantee(Origin::signed(2), (1, 50)), // 1 is not validtor
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -1980,7 +1980,7 @@ fn wrong_vote_is_null() {
                 Staking::guarantee(Origin::signed(2), (2, 50)), // 2 cannot gurantee itself
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -1988,7 +1988,7 @@ fn wrong_vote_is_null() {
                 Staking::guarantee(Origin::signed(2), (15, 50)), // 15 doesn't exist
                 DispatchError::Module {
                     index: 0,
-                    error: 4,
+                    error: 6,
                     message: Some("InvalidTarget"),
                 }
             );
@@ -3803,7 +3803,7 @@ fn cut_guarantee_should_work() {
             Staking::cut_guarantee(Origin::signed(2), (2, 250)),
             DispatchError::Module {
                 index: 0,
-                error: 4,
+                error: 6,
                 message: Some("InvalidTarget"),
             }
         );
@@ -3888,7 +3888,7 @@ fn cut_guarantee_should_work() {
             Staking::cut_guarantee(Origin::signed(2), (7, 1000)),
             DispatchError::Module {
                 index: 0,
-                error: 4,
+                error: 6,
                 message: Some("InvalidTarget"),
             }
         );

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -4214,7 +4214,7 @@ fn cut_guarantee_should_work() {
             }
         );
 
-        assert_eq!(Staking::guarantee_rel(3, 5).get(&(0 as u32)), None);
+        assert_eq!(Staking::guarantee_rel(3, 5).len(), 0);
         assert_eq!(Staking::guarantee_rel(1, 5).get(&(0 as u32)), Some(&(250 as Balance)));
         assert_eq!(Staking::guarantee_rel(1, 5).get(&(1 as u32)), Some(&(250 as Balance)));
         assert_eq!(Staking::guarantee_rel(1, 5).get(&(2 as u32)), Some(&(150 as Balance)));

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -4162,6 +4162,9 @@ fn cut_guarantee_should_work() {
             })
         );
         assert_eq!(Staking::guarantee_rel(3, 5).get(&(0 as u32)), Some(&(1000 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(0 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(1 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(2 as u32)), Some(&(250 as Balance)));
 
         assert_eq!(
             Staking::validators(&5),
@@ -4182,27 +4185,40 @@ fn cut_guarantee_should_work() {
                 guarantors: vec![1, 1, 3, 1, 1]
             }
         );
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(3 as u32)), Some(&(500 as Balance)));
 
-        assert_ok!(Staking::cut_guarantee(Origin::signed(2), (5, 1000)));
+        assert_ok!(Staking::cut_guarantee(Origin::signed(2), (5, 600)));
         assert_eq!(
             Staking::validators(&5),
             Validations{
-                total: 1250,
+                total: 1650,
                 guarantee_fee: Default::default(),
-                guarantors: vec![1, 3]
+                guarantors: vec![1, 1, 3, 1]
             }
         );
+
+        assert_eq!(Staking::guarantee_rel(3, 5).get(&(0 as u32)), Some(&(1000 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(0 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(1 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(2 as u32)), Some(&(150 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(3 as u32)), None);
 
         assert_ok!(Staking::cut_guarantee(Origin::signed(4), (5, 1000)));
 
         assert_eq!(
             Staking::validators(&5),
             Validations{
-                total: 250,
+                total: 650,
                 guarantee_fee: Default::default(),
-                guarantors: vec![1]
+                guarantors: vec![1, 1, 1]
             }
         );
+
+        assert_eq!(Staking::guarantee_rel(3, 5).get(&(0 as u32)), None);
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(0 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(1 as u32)), Some(&(250 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(2 as u32)), Some(&(150 as Balance)));
+        assert_eq!(Staking::guarantee_rel(1, 5).get(&(3 as u32)), None);
 
         assert_ok!(Staking::cut_guarantee(Origin::signed(2), (7, 1000))); // only 500 is valid
         assert_noop!(
@@ -4225,7 +4241,7 @@ fn cut_guarantee_should_work() {
             Staking::guarantors(&1),
             Some(Nominations {
                 targets: vec![5],
-                total: 250,
+                total: 650,
                 submitted_in: 0,
                 suppressed: false
             })
@@ -4235,16 +4251,16 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
-                total: 750,
+                total: 1150,
                 guarantee_fee: Default::default(),
-                guarantors: vec![1, 1]
+                guarantors: vec![1, 1, 1, 1]
             }
         );
         assert_eq!(
             Staking::guarantors(&1),
             Some(Nominations {
                 targets: vec![5],
-                total: 750,
+                total: 1150,
                 submitted_in: 0,
                 suppressed: false
             })

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -3423,7 +3423,7 @@ fn guarantee_order_should_work() {
             assert_eq!(Staking::guarantee_rel(7, 5).get(&(0 as u32)), Some(&(1000 as Balance)));
 
 
-            assert_ok!(Staking::cancel_guarantee(Origin::signed(2), (5, 1000)));
+            assert_ok!(Staking::cut_guarantee(Origin::signed(2), (5, 1000)));
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
@@ -3527,7 +3527,7 @@ fn multi_guarantees_with_stake_limit_should_work() {
                 }
             );
 
-            assert_ok!(Staking::cancel_guarantee(Origin::signed(2), (11, 250)));
+            assert_ok!(Staking::cut_guarantee(Origin::signed(2), (11, 250)));
             assert_eq!(Staking::guarantee_rel(1, 11).get(&(0 as u32)), Some(&(250 as Balance)));
             assert_eq!(
                 Staking::validators(&11),
@@ -3704,7 +3704,7 @@ fn new_era_with_stake_limit_should_work() {
 }
 
 #[test]
-fn cancel_guarantee_should_work() {
+fn cut_guarantee_should_work() {
     ExtBuilder::default()
     .guarantee(false)
     .build()
@@ -3801,7 +3801,7 @@ fn cancel_guarantee_should_work() {
             }
         );
 
-        assert_ok!(Staking::cancel_guarantee(Origin::signed(2), (5, 1000)));
+        assert_ok!(Staking::cut_guarantee(Origin::signed(2), (5, 1000)));
         assert_eq!(
             Staking::validators(&5),
             Validations{
@@ -3810,7 +3810,7 @@ fn cancel_guarantee_should_work() {
             }
         );
 
-        assert_ok!(Staking::cancel_guarantee(Origin::signed(4), (5, 1000)));
+        assert_ok!(Staking::cut_guarantee(Origin::signed(4), (5, 1000)));
 
         assert_eq!(
             Staking::validators(&5),
@@ -3820,9 +3820,9 @@ fn cancel_guarantee_should_work() {
             }
         );
 
-        assert_ok!(Staking::cancel_guarantee(Origin::signed(2), (7, 1000))); // only 500 is valid
+        assert_ok!(Staking::cut_guarantee(Origin::signed(2), (7, 1000))); // only 500 is valid
         assert_noop!(
-            Staking::cancel_guarantee(Origin::signed(2), (7, 1000)),
+            Staking::cut_guarantee(Origin::signed(2), (7, 1000)),
             DispatchError::Module {
                 index: 0,
                 error: 4,

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -3699,7 +3699,40 @@ fn new_era_with_stake_limit_should_work() {
                     unlocking: vec![] // in time. no lock for such scenario.
                 })
             );
-            
+            start_era_with_new_workloads(6, false, 1, 200000000);
+            start_era_with_new_workloads(7, false, 1, 200000000);
+            start_era_with_new_workloads(8, false, 1, 200000000);
+            assert_eq!(Staking::stake_limit(&11).unwrap_or_default(), 2500);
+            // 3 would be removed from validators due to stake limite
+            assert_eq!(
+                Staking::validators(&11),
+                Validations{
+                    guarantee_fee: Perbill::one(),
+                    guarantors: vec![1]
+                }
+            );
+            assert_eq!(Staking::guarantee_rel(1, 11).get(&(0 as u32)), Some(&(1500 as Balance)));
+            assert_eq!(
+                Staking::stakers(11),
+                Exposure {
+                    total: 2500,
+                    own: 1000,
+                    others: vec![IndividualExposure {
+                        who: 1,
+                        value: 1500
+                    }]
+                }
+            );
+            assert_eq!(
+                Staking::ledger(&4),
+                Some(StakingLedger {
+                    stash: 3,
+                    total: 2000,
+                    active: 2000,
+                    valid: 0,
+                    unlocking: vec![] // in time. no lock for such scenario.
+                })
+            );
         });
 }
 

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -3265,8 +3265,8 @@ fn guarantee_order_should_work() {
                 let _ = Balances::deposit_creating(&i, 5000);
             }
 
-            Staking::upsert_stake_limit(&5, 3500);
-            assert_eq!(Staking::stake_limit(&5).unwrap_or_default(), 3500);
+            Staking::upsert_stake_limit(&5, 5000);
+            assert_eq!(Staking::stake_limit(&5).unwrap_or_default(), 5000);
 
             // add a new validator candidate
             assert_ok!(Staking::bond(
@@ -3284,7 +3284,6 @@ fn guarantee_order_should_work() {
                 2000,
                 RewardDestination::Controller
             ));
-            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 1000)]));
 
             // add guarantor
             assert_ok!(Staking::bond(
@@ -3293,7 +3292,20 @@ fn guarantee_order_should_work() {
                 2000,
                 RewardDestination::Controller
             ));
+
+            assert_ok!(Staking::bond(
+                Origin::signed(7),
+                8,
+                2000,
+                RewardDestination::Controller
+            ));
+
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 250)]));
+            assert_ok!(Staking::guarantee(Origin::signed(8), vec![(5, 1000)]));
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 500)]));
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 750)]));
             assert_ok!(Staking::guarantee(Origin::signed(4), vec![(5, 1000)]));
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 1000)]));
 
             // guarantor's info guarantors should ✅
             assert_eq!(
@@ -3317,19 +3329,20 @@ fn guarantee_order_should_work() {
             assert_eq!(Staking::guarantee_rel(3, 5).unwrap().total, 1000);
 
             assert_eq!(
-                Staking::guarantors(&3),
+                Staking::guarantors(&7),
                 Some(Nominations {
                     targets: vec![5],
                     submitted_in: 0,
                     suppressed: false
                 })
             );
+            assert_eq!(Staking::guarantee_rel(7, 5).unwrap().total, 1000);
 
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
                     guarantee_fee: Default::default(),
-                    guarantors: vec![1, 3]
+                    guarantors: vec![1, 7, 1, 1, 3, 1]
                 }
             );
             // re-guarantee. The order should change
@@ -3339,9 +3352,17 @@ fn guarantee_order_should_work() {
                 Staking::validators(&5),
                 Validations{
                     guarantee_fee: Default::default(),
-                    guarantors: vec![3, 1]
+                    guarantors: vec![1, 7, 1, 1, 3, 1, 1]
                 }
             );
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(0 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(1 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(2 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(3 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(4 as u32)), Some(&(500 as Balance)));
+            assert_eq!(Staking::guarantee_rel(3, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+            assert_eq!(Staking::guarantee_rel(7, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+
 
             // re-guarantee with same stakes. The order should keep same
             assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 1500)]));
@@ -3350,9 +3371,170 @@ fn guarantee_order_should_work() {
                 Staking::validators(&5),
                 Validations{
                     guarantee_fee: Default::default(),
-                    guarantors: vec![3, 1]
+                    guarantors: vec![1, 7, 1, 1, 3, 1, 1]
                 }
             );
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 500)]));
+            assert_eq!(
+                Staking::validators(&5),
+                Validations{
+                    guarantee_fee: Default::default(),
+                    guarantors: vec![1, 7, 1, 3]
+                }
+            );
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(0 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(1 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(2 as u32)), None);
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(3 as u32)), None);
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(4 as u32)), None);
+            assert_eq!(Staking::guarantee_rel(3, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+            assert_eq!(Staking::guarantee_rel(7, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+        });
+}
+
+#[test]
+fn multi_guarantees_with_stake_limit_should_work() {
+    ExtBuilder::default()
+        .guarantee(false)
+        .own_workload(1)
+        .total_workload(100000000)
+        .build()
+        .execute_with(|| {
+            // put some money in account that we'll use.
+            for i in 1..10 {
+                let _ = Balances::deposit_creating(&i, 5000);
+            }
+
+            start_era(1, false);
+            assert_eq!(Staking::stake_limit(&11).unwrap_or_default(), 5000);
+            start_era(4, false);
+            assert_eq!(Staking::stake_limit(&11).unwrap_or_default(), 5000);
+            // add guarantor
+            assert_ok!(Staking::bond(
+                Origin::signed(1),
+                2,
+                2000,
+                RewardDestination::Controller
+            ));
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(11, 250)]));
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(11, 500)]));
+
+            // add guarantor
+            assert_ok!(Staking::bond(
+                Origin::signed(3),
+                4,
+                1000,
+                RewardDestination::Controller
+            ));
+            assert_ok!(Staking::guarantee(Origin::signed(4), vec![(11, 2000)]));
+
+            // guarantor's info guarantors should ✅
+            assert_eq!(
+                Staking::guarantors(&1),
+                Some(Nominations {
+                    targets: vec![11],
+                    submitted_in: 4,
+                    suppressed: false
+                })
+            );
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 500);
+
+            assert_eq!(
+                Staking::guarantors(&3),
+                Some(Nominations {
+                    targets: vec![11],
+                    submitted_in: 4,
+                    suppressed: false
+                })
+            );
+            assert_eq!(Staking::guarantee_rel(3, 11).unwrap().total, 1000);
+
+            assert_eq!(
+                Staking::guarantors(&3),
+                Some(Nominations {
+                    targets: vec![11],
+                    submitted_in: 4,
+                    suppressed: false
+                })
+            );
+
+            assert_eq!(
+                Staking::validators(&11),
+                Validations{
+                    guarantee_fee: Perbill::one(),
+                    guarantors: vec![1, 1, 3]
+                }
+            );
+
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(11, 250)]));
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 250);
+            assert_eq!(
+                Staking::validators(&11),
+                Validations{
+                    guarantee_fee: Perbill::one(),
+                    guarantors: vec![1, 3]
+                }
+            );
+
+
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(11, 1000)]));
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 1000);
+            assert_eq!(
+                Staking::validators(&11),
+                Validations{
+                    guarantee_fee: Perbill::one(),
+                    guarantors: vec![1, 3, 1]
+                }
+            );
+
+            start_era_with_new_workloads(5, false, 1, 200000000);
+            assert_eq!(Staking::stake_limit(&11).unwrap_or_default(), 2500);
+            // 3 would be removed from validators due to stake limite
+            assert_eq!(
+                Staking::validators(&11),
+                Validations{
+                    guarantee_fee: Perbill::one(),
+                    guarantors: vec![1, 3, 1]
+                }
+            );
+            assert_eq!(Staking::guarantee_rel(1, 11).unwrap().total, 500);
+            assert_eq!(
+                Staking::stakers(11),
+                Exposure {
+                    total: 2500,
+                    own: 1000,
+                    others: vec![IndividualExposure {
+                        who: 1,
+                        value: 500
+                    },
+                    IndividualExposure {
+                        who: 3,
+                        value: 1000
+                    }]
+                }
+            );
+            assert_eq!(
+                Staking::ledger(&4),
+                Some(StakingLedger {
+                    stash: 3,
+                    total: 1000,
+                    active: 1000,
+                    valid: 1000,
+                    unlocking: vec![]
+                })
+            );
+
+            assert_eq!(
+                Staking::ledger(&2),
+                Some(StakingLedger {
+                    stash: 1,
+                    total: 2000,
+                    active: 2000,
+                    valid: 500,
+                    unlocking: vec![]
+                })
+            );
+            
         });
 }
 

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -3389,6 +3389,23 @@ fn guarantee_order_should_work() {
             assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(4 as u32)), None);
             assert_eq!(Staking::guarantee_rel(3, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
             assert_eq!(Staking::guarantee_rel(7, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+
+
+            assert_ok!(Staking::guarantee(Origin::signed(2), vec![(5, 1000)]));
+            assert_eq!(
+                Staking::validators(&5),
+                Validations{
+                    guarantee_fee: Default::default(),
+                    guarantors: vec![1, 7, 1, 3, 1]
+                }
+            );
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(0 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(1 as u32)), Some(&(250 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(2 as u32)), Some(&(500 as Balance)));
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(3 as u32)), None);
+            assert_eq!(Staking::guarantee_rel(1, 5).unwrap().records.get(&(4 as u32)), None);
+            assert_eq!(Staking::guarantee_rel(3, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
+            assert_eq!(Staking::guarantee_rel(7, 5).unwrap().records.get(&(0 as u32)), Some(&(1000 as Balance)));
         });
 }
 

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -86,6 +86,7 @@ fn basic_setup_works() {
                 (
                     21,
                     Validations {
+                        total: 250,
                         guarantee_fee: Perbill::one(),
                         guarantors: vec![101]
                     }
@@ -93,6 +94,7 @@ fn basic_setup_works() {
                 (
                     11,
                     Validations {
+                        total: 250,
                         guarantee_fee: Perbill::one(),
                         guarantors: vec![101]
                     }
@@ -1311,6 +1313,7 @@ fn validator_payment_prefs_work() {
         <Validators<Test>>::insert(
             &11,
             Validations {
+                total: 0,
                 guarantee_fee: Perbill::from_percent(50),
                 guarantors: vec![],
             },
@@ -3400,6 +3403,7 @@ fn guarantee_order_should_work() {
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
+                    total: 3000,
                     guarantee_fee: Default::default(),
                     guarantors: vec![1, 7, 1, 1, 3, 1]
                 }
@@ -3410,6 +3414,7 @@ fn guarantee_order_should_work() {
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
+                    total: 3500,
                     guarantee_fee: Default::default(),
                     guarantors: vec![1, 7, 1, 1, 3, 1, 1]
                 }
@@ -3427,6 +3432,7 @@ fn guarantee_order_should_work() {
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
+                    total: 2500,
                     guarantee_fee: Default::default(),
                     guarantors: vec![1, 7, 1, 3]
                 }
@@ -3444,6 +3450,7 @@ fn guarantee_order_should_work() {
             assert_eq!(
                 Staking::validators(&5),
                 Validations{
+                    total: 3000,
                     guarantee_fee: Default::default(),
                     guarantors: vec![1, 7, 1, 3, 1]
                 }
@@ -3522,6 +3529,7 @@ fn multi_guarantees_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 1500,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1, 1, 3]
                 }
@@ -3532,6 +3540,7 @@ fn multi_guarantees_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 1250,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1, 3]
                 }
@@ -3544,6 +3553,7 @@ fn multi_guarantees_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 2000,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1, 3, 1]
                 }
@@ -3555,6 +3565,7 @@ fn multi_guarantees_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 1500,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1, 3, 1]
                 }
@@ -3662,6 +3673,7 @@ fn new_era_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 4000,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1, 3]
                 }
@@ -3673,6 +3685,7 @@ fn new_era_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 1500,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1]
                 }
@@ -3707,6 +3720,7 @@ fn new_era_with_stake_limit_should_work() {
             assert_eq!(
                 Staking::validators(&11),
                 Validations{
+                    total: 1500,
                     guarantee_fee: Perbill::one(),
                     guarantors: vec![1]
                 }
@@ -3831,6 +3845,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
+                total: 1750,
                 guarantee_fee: Default::default(),
                 guarantors: vec![1, 1, 3, 1]
             }
@@ -3841,6 +3856,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
+                total: 2250,
                 guarantee_fee: Default::default(),
                 guarantors: vec![1, 1, 3, 1, 1]
             }
@@ -3850,6 +3866,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
+                total: 1250,
                 guarantee_fee: Default::default(),
                 guarantors: vec![1, 3]
             }
@@ -3860,6 +3877,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
+                total: 250,
                 guarantee_fee: Default::default(),
                 guarantors: vec![1]
             }
@@ -3877,6 +3895,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&7),
             Validations{
+                total: 0,
                 guarantee_fee: Default::default(),
                 guarantors: vec![]
             }
@@ -3895,6 +3914,7 @@ fn cut_guarantee_should_work() {
         assert_eq!(
             Staking::validators(&5),
             Validations{
+                total: 750,
                 guarantee_fee: Default::default(),
                 guarantors: vec![1, 1]
             }


### PR DESCRIPTION
Fix #95
Guarantor increasing his votes won't bring side-effect.
- Questions
    - What will happen when several guarantors  guarantee concurrently.
    - Guarantor can attack the blockchain by calling `guarantee` millions of times. Each time he just increases his vote with a minimal staking.

Fix #118