### PR TITLE
[Market] add completed_on in storage order for delay payment and fix a potential bug

### DIFF
--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -32,6 +32,7 @@ pub struct StorageOrder<AccountId> {
     pub file_identifier: MerkleRoot,
     pub file_size: u64,
     pub created_on: BlockNumber,
+    pub effected_on: BlockNumber,
     pub expired_on: BlockNumber,
     pub provider: AccountId,
     pub client: AccountId,
@@ -247,6 +248,7 @@ decl_module! {
                     file_identifier,
                     file_size,
                     created_on,
+                    effected_on: created_on,
                     expired_on: created_on + duration, // this will changed, when `order_status` become `Success`
                     provider: provider.clone(),
                     client: who.clone(),

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -32,7 +32,7 @@ pub struct StorageOrder<AccountId> {
     pub file_identifier: MerkleRoot,
     pub file_size: u64,
     pub created_on: BlockNumber,
-    pub effected_on: BlockNumber,
+    pub completed_on: BlockNumber,
     pub expired_on: BlockNumber,
     pub provider: AccountId,
     pub client: AccountId,
@@ -248,7 +248,7 @@ decl_module! {
                     file_identifier,
                     file_size,
                     created_on,
-                    effected_on: created_on,
+                    completed_on: created_on,
                     expired_on: created_on + duration, // this will changed, when `order_status` become `Success`
                     provider: provider.clone(),
                     client: who.clone(),

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -38,6 +38,7 @@ fn test_for_storage_order_should_work() {
             file_identifier,
             file_size: 16,
             created_on: 50,
+            effected_on: 50,
             expired_on: 410,
             provider: 100,
             client: 0,

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -38,7 +38,7 @@ fn test_for_storage_order_should_work() {
             file_identifier,
             file_size: 16,
             created_on: 50,
-            effected_on: 50,
+            completed_on: 50,
             expired_on: 410,
             provider: 100,
             client: 0,

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -291,12 +291,12 @@ impl<T: Trait> Module<T> {
 
                 // TODO: we should specially handle `Failed` status
                 if sorder.order_status != OrderStatus::Success {
-                    // 1. Reset `expired_on` and `effected_on` for new order
+                    // 1. Reset `expired_on` and `completed_on` for new order
                     if sorder.order_status == OrderStatus::Pending {
                         let current_block_numeric = Self::get_current_block_number();
                         // go panic if `current_block_numeric` > `created_on`
                         sorder.expired_on += current_block_numeric - sorder.created_on;
-                        sorder.effected_on = current_block_numeric;
+                        sorder.completed_on = current_block_numeric;
                     }
 
                     // 2. Change order status to `Success`

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -291,7 +291,7 @@ impl<T: Trait> Module<T> {
 
                 // TODO: we should specially handle `Failed` status
                 if sorder.order_status != OrderStatus::Success {
-                    // 1. Reset `expired_on` for new order
+                    // 1. Reset `expired_on` and `effected_on` for new order
                     if sorder.order_status == OrderStatus::Pending {
                         let current_block_numeric = Self::get_current_block_number();
                         // go panic if `current_block_numeric` > `created_on`

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -291,15 +291,16 @@ impl<T: Trait> Module<T> {
 
                 // TODO: we should specially handle `Failed` status
                 if sorder.order_status != OrderStatus::Success {
-                    // 1. Change order status to `Success`
-                    sorder.order_status = OrderStatus::Success;
-
-                    // 2. Reset `expired_on` for new order
+                    // 1. Reset `expired_on` for new order
                     if sorder.order_status == OrderStatus::Pending {
                         let current_block_numeric = Self::get_current_block_number();
                         // go panic if `current_block_numeric` > `created_on`
                         sorder.expired_on += current_block_numeric - sorder.created_on;
+                        sorder.effected_on = current_block_numeric;
                     }
+
+                    // 2. Change order status to `Success`
+                    sorder.order_status = OrderStatus::Success;
 
                     // 3. (Maybe) set sorder
                     T::MarketInterface::maybe_set_sorder(order_id, &sorder);

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -143,6 +143,7 @@ pub fn upsert_sorder_to_provider(who: &AccountId, f_id: &MerkleRoot, rd: u8, os:
         file_identifier: f_id.clone(),
         file_size: 0,
         created_on: 0,
+        effected_on: 0,
         expired_on: 0,
         provider: who.clone(),
         client: who.clone(),

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -143,7 +143,7 @@ pub fn upsert_sorder_to_provider(who: &AccountId, f_id: &MerkleRoot, rd: u8, os:
         file_identifier: f_id.clone(),
         file_size: 0,
         created_on: 0,
-        effected_on: 0,
+        completed_on: 0,
         expired_on: 0,
         provider: who.clone(),
         client: who.clone(),

--- a/cstrml/tee/src/tests.rs
+++ b/cstrml/tee/src/tests.rs
@@ -210,6 +210,8 @@ fn test_for_report_works_success() {
         // prepare sorder
         add_pending_sorder();
 
+        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 0);
+
         let account: AccountId = Sr25519Keyring::Bob.to_account_id();
 
         // Check workloads
@@ -225,6 +227,7 @@ fn test_for_report_works_success() {
         assert_eq!(Tee::used(), 402868224);
         assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().order_status,
                    OrderStatus::Success);
+        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 303);
     });
 }
 


### PR DESCRIPTION
need to calcute the piece of each transfer. Since expired_on will be changed, the information of the duration has been lost.