### PR TITLE
[Market] Change Sorder price into provider side

### DIFF
--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup, SaturatedConversion},
     Perbill,
 };
 use std::{cell::RefCell};
@@ -36,6 +36,30 @@ pub struct ExistentialDeposit;
 impl Get<u64> for ExistentialDeposit {
     fn get() -> u64 {
         EXISTENTIAL_DEPOSIT.with(|v| *v.borrow())
+    }
+}
+
+pub struct CurrencyToVoteHandler;
+impl Convert<u64, u64> for CurrencyToVoteHandler {
+    fn convert(x: u64) -> u64 {
+        x
+    }
+}
+impl Convert<u128, u64> for CurrencyToVoteHandler {
+    fn convert(x: u128) -> u64 {
+        x.saturated_into()
+    }
+}
+
+impl Convert<u128, u128> for CurrencyToVoteHandler {
+    fn convert(x: u128) -> u128 {
+        x
+    }
+}
+
+impl Convert<u64, u128> for CurrencyToVoteHandler {
+    fn convert(x: u64) -> u128 {
+        x as u128
     }
 }
 
@@ -114,7 +138,7 @@ impl Payment<<Test as system::Trait>::AccountId,
 
 impl Trait for Test {
     type Currency = Balances;
-    type CurrencyToBalance = ();
+    type CurrencyToBalance = CurrencyToVoteHandler;
     type Event = ();
     type Randomness = ();
     type Payment = Market;

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -44,6 +44,8 @@ parameter_types! {
     pub const MaximumBlockWeight: Weight = 1024;
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+    pub const MinimumStoragePrice: Balance = 1;
+    pub const MinimumSorderDuration: u32 = 1;
 }
 
 impl system::Trait for Test {
@@ -112,10 +114,13 @@ impl Payment<<Test as system::Trait>::AccountId,
 
 impl Trait for Test {
     type Currency = Balances;
+    type CurrencyToBalance = ();
     type Event = ();
     type Randomness = ();
     type Payment = Market;
     type OrderInspector = TestOrderInspector;
+    type MinimumStoragePrice = MinimumStoragePrice;
+    type MinimumSorderDuration = MinimumSorderDuration;
 }
 
 pub type Market = Module<Test>;

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -64,7 +64,7 @@ fn test_for_storage_order_should_work() {
             file_size: 16,
             created_on: 50,
             completed_on: 50,
-            expired_on: 410,
+            expired_on: 50+10*10,
             provider,
             client,
             amount,
@@ -82,7 +82,7 @@ fn test_for_storage_order_should_work() {
         });
         assert_eq!(Market::pledges(provider), Pledge {
             total: 60,
-            used: fee
+            used: amount
         });
     });
 }
@@ -390,7 +390,7 @@ fn test_for_storage_order_should_fail_due_to_insufficient_pledge() {
             file_size: 16,
             created_on: 50,
             completed_on: 50,
-            expired_on: 410,
+            expired_on: 50+60*10,
             provider: 100,
             client: 0,
             amount,

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -406,7 +406,7 @@ fn test_for_pledge_should_fail_due_to_double_pledge() {
             DispatchError::Module {
                 index: 0,
                 error: 8,
-                message: Some("DoublePledged")
+                message: Some("AlreadyPledged")
             }
         );
     });

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -20,23 +20,25 @@ fn test_for_storage_order_should_work() {
         let provider: u64 = 100;
         let client: u64 = 0;
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 10;
+        let duration = 10;
+        let fee: u64 = 1;
+        let amount: u64 = 10;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
-        let _ = Balances::make_free_balance_be(&source, 80);
+        let _ = Balances::make_free_balance_be(&source, 60);
 
         // 1. Normal flow, aka happy pass 😃
-        let _ = Balances::make_free_balance_be(&provider, 80);
+        let _ = Balances::make_free_balance_be(&provider, 60);
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 60));
         assert_ok!(Market::cut_pledge(Origin::signed(provider.clone()), 60));
-        assert!(!<PledgeLedgers<Test>>::contains_key(provider.clone()));
+        assert!(!<Pledges<Test>>::contains_key(provider.clone()));
         assert_eq!(Balances::locks(provider.clone()).len(), 0);
+
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 60));
-        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone()));
+        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
 
         assert_noop!(
             Market::place_storage_order(
-                Origin::signed(provider.clone()), provider.clone(), fee,
+                Origin::signed(provider.clone()), provider.clone(),
                 file_identifier.clone(), file_size, duration
             ),
             DispatchError::Module {
@@ -46,13 +48,14 @@ fn test_for_storage_order_should_work() {
             }
         );
         assert_ok!(Market::place_storage_order(
-            Origin::signed(source), provider, fee,
+            Origin::signed(source), provider,
             file_identifier.clone(), file_size, duration
         ));
 
         let order_id = H256::default();
         assert_eq!(Market::providers(&provider).unwrap(), Provision {
             address_info,
+            storage_price: fee,
             file_map: vec![(file_identifier.clone(), vec![order_id.clone()])].into_iter().collect()
         });
         assert_eq!(Market::clients(&client).unwrap(), vec![order_id.clone()]);
@@ -64,18 +67,20 @@ fn test_for_storage_order_should_work() {
             expired_on: 410,
             provider,
             client,
-            amount: fee,
+            amount,
             status: OrderStatus::Pending
         });
 
         // 2. Register after get order, address should update but others should not
         let another_address_info = "ws://127.0.0.1:9900".as_bytes().to_vec();
-        assert_ok!(Market::register(Origin::signed(provider.clone()), another_address_info.clone()));
+        let another_price: u64 = 2;
+        assert_ok!(Market::register(Origin::signed(provider.clone()), another_address_info.clone(), another_price));
         assert_eq!(Market::providers(&provider).unwrap(), Provision {
             address_info: another_address_info.clone(),
+            storage_price: another_price,
             file_map: vec![(file_identifier.clone(), vec![order_id.clone()])].into_iter().collect()
         });
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 60,
             used: fee
         });
@@ -93,16 +98,16 @@ fn test_for_storage_order_should_fail_due_to_file_size() {
         hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
         let provider = 100;
         let file_size = 200; // should less than provider
-        let duration = 360;
-        let fee = 10;
+        let duration = 10;
+        let fee = 1;
         let address = "ws://127.0.0.1:8855".as_bytes().to_vec();
 
 
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 0));
-        assert_ok!(Market::register(Origin::signed(provider), address.clone()));
+        assert_ok!(Market::register(Origin::signed(provider), address.clone(), fee));
         assert_noop!(
             Market::place_storage_order(
-                Origin::signed(source.clone()), provider, fee,
+                Origin::signed(source.clone()), provider,
                 file_identifier, file_size, duration
             ),
             DispatchError::Module {
@@ -115,7 +120,7 @@ fn test_for_storage_order_should_fail_due_to_file_size() {
 }
 
 #[test]
-fn test_for_storage_order_should_fail_due_to_wrong_expired() {
+fn test_for_storage_order_should_fail_due_to_duration_too_short() {
     new_test_ext().execute_with(|| {
         // generate 50 blocks first
         run_to_block(50);
@@ -125,15 +130,15 @@ fn test_for_storage_order_should_fail_due_to_wrong_expired() {
             hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
         let provider = 100;
         let file_size = 60; // should less than provider
-        let duration = 20;
-        let fee = 10;
+        let duration = 1; // shoule more than 1 minute
+        let fee = 1;
         let address = "ws://127.0.0.1:8855".as_bytes().to_vec();
 
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 0));
-        assert_ok!(Market::register(Origin::signed(provider), address.clone()));
+        assert_ok!(Market::register(Origin::signed(provider), address.clone(), fee));
         assert_noop!(
             Market::place_storage_order(
-                Origin::signed(source.clone()), provider, fee,
+                Origin::signed(source.clone()), provider,
                 file_identifier, file_size, duration
             ),
             DispatchError::Module {
@@ -146,7 +151,27 @@ fn test_for_storage_order_should_fail_due_to_wrong_expired() {
 }
 
 #[test]
-fn test_for_storage_order_should_fail_due_to_exist_of_wr() {
+fn test_for_register_should_fail_due_to_low_price() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let provider = 100;
+        let address = "ws://127.0.0.1:8855".as_bytes().to_vec();
+        assert_ok!(Market::pledge(Origin::signed(provider.clone()), 0));
+        assert_noop!(
+            Market::register(Origin::signed(provider), address.clone(), 0),
+            DispatchError::Module {
+                index: 0,
+                error: 10,
+                message: Some("LowStoragePrice"),
+            }
+        );
+    });
+}
+
+#[test]
+fn test_for_storage_order_should_fail_due_to_wr_not_exist() {
     new_test_ext().execute_with(|| {
         // generate 50 blocks first
         run_to_block(50);
@@ -155,7 +180,7 @@ fn test_for_storage_order_should_fail_due_to_exist_of_wr() {
         let address = "ws://127.0.0.1:8855".as_bytes().to_vec();
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 0));
         assert_noop!(
-            Market::register(Origin::signed(provider), address.clone()),
+            Market::register(Origin::signed(provider), address.clone(), 1),
             DispatchError::Module {
                 index: 0,
                 error: 1,
@@ -176,12 +201,11 @@ fn test_for_storage_order_should_fail_due_to_provider_not_register() {
             hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
         let provider = 100;
         let file_size = 80; // should less than provider
-        let duration = 360;
-        let fee = 10;
+        let duration = 10;
 
         assert_noop!(
             Market::place_storage_order(
-                Origin::signed(source.clone()), provider, fee,
+                Origin::signed(source.clone()), provider,
                 file_identifier, file_size, duration
             ),
             DispatchError::Module {
@@ -202,18 +226,18 @@ fn test_for_pledge_should_work() {
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
         let _ = Balances::make_free_balance_be(&provider, 200);
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 180));
-        assert_ok!(Market::register(Origin::signed(provider), address_info.clone()));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_ok!(Market::register(Origin::signed(provider), address_info.clone(), 1));
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 180,
             used: 0
         });
         assert_ok!(Market::cut_pledge(Origin::signed(provider), 20));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 160,
             used: 0
         });
         assert_ok!(Market::pledge_extra(Origin::signed(provider), 10));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 170,
             used: 0
         });
@@ -221,7 +245,7 @@ fn test_for_pledge_should_work() {
 }
 
 #[test]
-fn test_for_pledge_extra_should_fail_due_to_provider_not_pledge() {
+fn test_for_pledge_extra_should_fail_due_to_provider_not_pledges() {
     new_test_ext().execute_with(|| {
         // generate 50 blocks first
         run_to_block(50);
@@ -276,25 +300,27 @@ fn test_for_pledge_should_fail_due_to_insufficient_pledge() {
         hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
         let provider = 100;
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 50;
+        let duration = 50;
+        let fee = 1;
+        let amount: u64 = 50;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
         let _ = Balances::make_free_balance_be(&source, 80);
         let _ = Balances::make_free_balance_be(&provider, 80);
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 70));
-        assert_ok!(Market::register(Origin::signed(provider), address_info.clone()));
+
+        assert_ok!(Market::register(Origin::signed(provider), address_info.clone(), fee));
         assert_ok!(Market::place_storage_order(
-            Origin::signed(source), provider, fee,
+            Origin::signed(source), provider,
             file_identifier.clone(), file_size, duration
         ));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 70,
-            used: fee
+            used: amount
         });
         assert_ok!(Market::cut_pledge(Origin::signed(provider), 20));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 50,
-            used: fee
+            used: amount
         });
         assert_noop!(
             Market::cut_pledge(
@@ -321,16 +347,17 @@ fn test_for_storage_order_should_fail_due_to_insufficient_pledge() {
         hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
         let provider = 100;
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 60;
+        let duration = 60;
+        let fee = 1;
+        let amount: u64 = 60;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
         let _ = Balances::make_free_balance_be(&source, 80);
         let _ = Balances::make_free_balance_be(&provider, 80);
         assert_ok!(Market::pledge(Origin::signed(provider), 0));
-        assert_ok!(Market::register(Origin::signed(provider), address_info.clone()));
+        assert_ok!(Market::register(Origin::signed(provider), address_info.clone(), fee));
         assert_noop!(
             Market::place_storage_order(
-                Origin::signed(source.clone()), provider, fee,
+                Origin::signed(source.clone()), provider,
                 file_identifier.clone(), file_size, duration
             ),
             DispatchError::Module {
@@ -339,29 +366,14 @@ fn test_for_storage_order_should_fail_due_to_insufficient_pledge() {
                 message: Some("InsufficientPledge"),
             }
         );
-        assert_ok!(Market::pledge_extra(Origin::signed(provider), 40));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
-            total: 40,
-            used: 0
-        });
-        assert_noop!(
-            Market::place_storage_order(
-                Origin::signed(source.clone()), provider, fee,
-                file_identifier.clone(), file_size, duration
-            ),
-            DispatchError::Module {
-                index: 0,
-                error: 5,
-                message: Some("InsufficientPledge"),
-            }
-        );
-        assert_ok!(Market::pledge_extra(Origin::signed(provider), 20));
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+
+        assert_ok!(Market::pledge_extra(Origin::signed(provider), 60));
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 60,
             used: 0
         });
         assert_ok!(Market::place_storage_order(
-            Origin::signed(source), provider, fee,
+            Origin::signed(source), provider,
             file_identifier.clone(), file_size, duration
         ));
 
@@ -369,9 +381,10 @@ fn test_for_storage_order_should_fail_due_to_insufficient_pledge() {
         
         assert_eq!(Market::providers(&provider).unwrap(), Provision {
             address_info,
+            storage_price: fee,
             file_map: vec![(file_identifier.clone(), vec![order_id.clone()])].into_iter().collect()
         });
-        assert_eq!(Market::clients(0).unwrap(), vec![order_id.clone()]);
+        assert_eq!(Market::clients(&0).unwrap(), vec![order_id.clone()]);
         assert_eq!(Market::storage_orders(order_id).unwrap(), StorageOrder {
             file_identifier,
             file_size: 16,
@@ -380,10 +393,10 @@ fn test_for_storage_order_should_fail_due_to_insufficient_pledge() {
             expired_on: 410,
             provider: 100,
             client: 0,
-            amount: fee,
+            amount,
             status: Default::default()
         });
-        assert_eq!(Market::pledge_ledgers(provider), PledgeLedger {
+        assert_eq!(Market::pledges(provider), Pledge {
             total: 60,
             used: 60
         });

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -63,10 +63,9 @@ impl<T: Trait> Payment<<T as system::Trait>::AccountId,
                 // 2. Calculate slots
                 // TODO: Change fixed time frequency to fixed slots
                 let minute = TryInto::<T::BlockNumber>::try_into(MINUTES).ok().unwrap();
-                let duration = so.expired_on - so.completed_on;
-                let slots = duration / MINUTES;
+                let slots = (so.expired_on - so.completed_on) / MINUTES;
                 let slot_amount = so.amount.checked_div(&<T::CurrencyToBalance
-                    as Convert<u64, BalanceOf<T>>>::convert(duration as u64)).unwrap();
+                    as Convert<u64, BalanceOf<T>>>::convert(slots as u64)).unwrap();
 
                 // 3. Arrange a scheduler
                 // TODO: What if returning an error?

--- a/cstrml/payment/src/mock.rs
+++ b/cstrml/payment/src/mock.rs
@@ -116,6 +116,8 @@ impl market::OrderInspector<AccountId> for TestOrderInspector {
 
 parameter_types! {
 	pub const MaximumWeight: u32 = 1000000;
+    pub const MinimumStoragePrice: Balance = 1;
+    pub const MinimumSorderDuration: u32 = 1;
 }
 
 impl scheduler::Trait for Test {
@@ -142,10 +144,13 @@ impl tee::Trait for Test {
 
 impl market::Trait for Test {
     type Currency = Balances;
+    type CurrencyToBalance = CurrencyToVoteHandler;
     type Event = ();
     type Randomness = ();
     type Payment = Payment;
     type OrderInspector = TestOrderInspector;
+    type MinimumStoragePrice = MinimumStoragePrice;
+    type MinimumSorderDuration = MinimumSorderDuration;
 }
 
 impl Trait for Test {

--- a/cstrml/payment/src/tests.rs
+++ b/cstrml/payment/src/tests.rs
@@ -48,8 +48,8 @@ fn test_for_storage_order_and_payment_should_work() {
         hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
         let provider: AccountId = Sr25519Keyring::Bob.to_account_id();
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 60;
+        let duration = 30;
+        let fee = 2;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
         let _ = Balances::make_free_balance_be(&client, 70);
         let _ = Balances::make_free_balance_be(&provider, pledge_amount);
@@ -57,9 +57,9 @@ fn test_for_storage_order_and_payment_should_work() {
 
         // Call register and place storage order
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), pledge_amount));
-        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone()));
+        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
         assert_ok!(Market::place_storage_order(
-            Origin::signed(client.clone()), provider.clone(), fee,
+            Origin::signed(client.clone()), provider.clone(),
             file_identifier.clone(), file_size, duration
         ));
 
@@ -119,19 +119,21 @@ fn test_for_storage_order_and_payment_should_failed_by_insufficient_currency() {
         hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
         let provider: AccountId = Sr25519Keyring::Bob.to_account_id();
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 60;
+        let duration = 60;
+        let fee = 1;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
-        let _ = Balances::make_free_balance_be(&source, 40);
-        assert_eq!(Balances::free_balance(source.clone()), 40);
 
-        assert_ok!(Market::pledge(Origin::signed(provider.clone()), 0));
-        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone()));
+        Balances::make_free_balance_be(&source, 40);
+        Balances::make_free_balance_be(&provider, 60);
+        assert_eq!(Balances::free_balance(source.clone()), 40);
+        assert_eq!(Balances::free_balance(provider.clone()), 60);
+
+        assert_ok!(Market::pledge(Origin::signed(provider.clone()), 60));
+        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
         assert_noop!(
             Market::place_storage_order(
-            Origin::signed(source.clone()), provider.clone(), fee,
-            file_identifier.clone(), file_size, duration
-            ),
+            Origin::signed(source.clone()), provider.clone(),
+            file_identifier.clone(), file_size, duration),
             DispatchError::Module {
                 index: 0,
                 error: 4,
@@ -153,17 +155,17 @@ fn test_for_storage_order_and_payment_should_suspend() {
         hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
         let provider: AccountId = Sr25519Keyring::Bob.to_account_id();
         let file_size = 16; // should less than provider
-        let duration = 360; // file should store at least 30 minutes
-        let fee = 60;
+        let duration = 30;
+        let fee = 2;
         let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
         let _ = Balances::make_free_balance_be(&source, 70);
         let _ = Balances::make_free_balance_be(&provider, pledge_amount);
         assert_eq!(Balances::free_balance(source.clone()), 70);
 
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), pledge_amount));
-        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone()));
+        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
         assert_ok!(Market::place_storage_order(
-            Origin::signed(source.clone()), provider.clone(), fee,
+            Origin::signed(source.clone()), provider.clone(),
             file_identifier.clone(), file_size, duration
         ));
 

--- a/cstrml/tee/src/api.rs
+++ b/cstrml/tee/src/api.rs
@@ -224,4 +224,6 @@ DaVzWh5aiEx+idkSGMnX
         }
         None
     }
+    // ✅ 1. use wasm version, (p256 -> scep256k1 | x509 -> wasm version)
+    // 2. offchain_worker? forkless upgrade?
 }

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -220,14 +220,14 @@ decl_module! {
             let who = ensure_signed(origin)?;
 
             // 1. Ensure reporter is verified
-            ensure!(<TeeIdentities<T>>::contains_key(&who), Error::<T>::IllegalReporter);
-            ensure!(&<TeeIdentities<T>>::get(&who).unwrap().pub_key == &work_report.pub_key, Error::<T>::InvalidPubKey);
+            // ensure!(<TeeIdentities<T>>::contains_key(&who), Error::<T>::IllegalReporter);
+            // ensure!(&<TeeIdentities<T>>::get(&who).unwrap().pub_key == &work_report.pub_key, Error::<T>::InvalidPubKey);
 
             // 2. Do timing check
-            ensure!(Self::work_report_timing_check(&work_report).is_ok(), Error::<T>::InvalidReportTime);
+            // ensure!(Self::work_report_timing_check(&work_report).is_ok(), Error::<T>::InvalidReportTime);
 
             // 3. Do sig check
-            ensure!(Self::work_report_sig_check(&work_report), Error::<T>::IllegalWorkReportSig);
+            // ensure!(Self::work_report_sig_check(&work_report), Error::<T>::IllegalWorkReportSig);
 
             // 4. Maybe upsert work report
             if Self::maybe_upsert_work_report(&who, &work_report) {

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -220,14 +220,14 @@ decl_module! {
             let who = ensure_signed(origin)?;
 
             // 1. Ensure reporter is verified
-            // ensure!(<TeeIdentities<T>>::contains_key(&who), Error::<T>::IllegalReporter);
-            // ensure!(&<TeeIdentities<T>>::get(&who).unwrap().pub_key == &work_report.pub_key, Error::<T>::InvalidPubKey);
+            ensure!(<TeeIdentities<T>>::contains_key(&who), Error::<T>::IllegalReporter);
+            ensure!(&<TeeIdentities<T>>::get(&who).unwrap().pub_key == &work_report.pub_key, Error::<T>::InvalidPubKey);
 
             // 2. Do timing check
-            // ensure!(Self::work_report_timing_check(&work_report).is_ok(), Error::<T>::InvalidReportTime);
+            ensure!(Self::work_report_timing_check(&work_report).is_ok(), Error::<T>::InvalidReportTime);
 
             // 3. Do sig check
-            // ensure!(Self::work_report_sig_check(&work_report), Error::<T>::IllegalWorkReportSig);
+            ensure!(Self::work_report_sig_check(&work_report), Error::<T>::IllegalWorkReportSig);
 
             // 4. Maybe upsert work report
             if Self::maybe_upsert_work_report(&who, &work_report) {

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -96,10 +96,13 @@ impl market::Payment<<Test as system::Trait>::AccountId,
 
 impl market::Trait for Test {
     type Currency = balances::Module<Self>;
+    type CurrencyToBalance = ();
     type Event = ();
     type Randomness = ();
     type Payment = Tee;
     type OrderInspector = Tee;
+    type MinimumStoragePrice = ();
+    type MinimumSorderDuration = ();
 }
 
 impl Trait for Test {
@@ -196,6 +199,7 @@ pub fn upsert_sorder_to_provider(who: &AccountId, f_id: &MerkleRoot, rd: u8, os:
 
     let provision = Provision {
         address_info: vec![],
+        storage_price: 1,
         file_map
     };
     <market::Providers<Test>>::insert(who, provision);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,7 @@ use session::{historical as session_historical};
 pub use timestamp::Call as TimestampCall;
 
 /// Crust primitives
-use primitives::{constants::{time::*, currency::*}, *};
+use primitives::{constants::{time::*, currency::*, tee::REPORT_SLOT}, *};
 
 #[cfg(feature = "std")]
 pub use staking::StakerStatus;
@@ -405,13 +405,21 @@ impl tee::Trait for Runtime {
     type MarketInterface = Market;
 }
 
+parameter_types! {
+	pub const MinimumStoragePrice: Balance = 40;
+	pub const MinimumSorderDuration: u32 = REPORT_SLOT as u32;
+}
+
 impl market::Trait for Runtime {
     type Currency = Balances;
+    type CurrencyToBalance = CurrencyToVoteHandler;
     type Event = Event;
     type Randomness = RandomnessCollectiveFlip;
     // TODO: Bonding with balance module(now we impl inside Market)
     type Payment = Payment;
     type OrderInspector = Tee;
+    type MinimumStoragePrice = MinimumStoragePrice;
+    type MinimumSorderDuration = MinimumSorderDuration;
 }
 
 impl payment::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,10 @@ use session::{historical as session_historical};
 pub use timestamp::Call as TimestampCall;
 
 /// Crust primitives
-use primitives::{constants::{time::*, currency::*, tee::REPORT_SLOT}, *};
+use primitives::{
+    constants::{time::*, currency::*, tee::REPORT_SLOT},
+    *
+};
 
 #[cfg(feature = "std")]
 pub use staking::StakerStatus;
@@ -406,8 +409,10 @@ impl tee::Trait for Runtime {
 }
 
 parameter_types! {
+    /// Unit is pico
 	pub const MinimumStoragePrice: Balance = 40;
-	pub const MinimumSorderDuration: u32 = REPORT_SLOT as u32;
+	/// Unit is minute
+	pub const MinimumSorderDuration: u32 = 30;
 }
 
 impl market::Trait for Runtime {


### PR DESCRIPTION
1. Add `storage_price` into provider's register;
2. Remove amount when place an sorder;
3. Change `duration` from 'block_number' into `minutes(10 blocks)`;
4. Simply rename `PledgeLedger` to `Pledge`;
5. Set 2 rules:
    - Minimum storage price now is 40 pico/megabytes/minute;
    - Minimum duration is around 30 minutes(300 blocks);

