### PR TITLE
[Market] Add virtual closed status for storage order

### DIFF
--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -103,6 +103,8 @@ pub trait Payment<AccountId, Hash, Balance> {
     fn reserve_sorder(sorder_id: &Hash, client: &AccountId, amount: Balance) -> bool;
     /// Start delayed payment for a reserved storage order
     fn pay_sorder(sorder_id: &Hash);
+    /// To remove closed sorder's payment info
+    fn close_sorder(sorder_id: &Hash, client: &AccountId);
 }
 
 /// A trait for checking order's legality
@@ -183,7 +185,7 @@ pub trait Trait: system::Trait {
     /// Something that provides randomness in the runtime.
     type Randomness: Randomness<Self::Hash>;
 
-    /// Connector with balance module
+    /// Connector with payment module
     type Payment: Payment<Self::AccountId, Self::Hash, BalanceOf<Self>>;
 
     /// Connector with tee module

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -135,6 +135,8 @@ impl Payment<<Test as system::Trait>::AccountId,
     }
 
     fn pay_sorder(_: &<Test as system::Trait>::Hash) { }
+
+    fn close_sorder(_: &Hash, _: &AccountId) { }
 }
 
 parameter_types! {

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -136,7 +136,7 @@ impl Payment<<Test as system::Trait>::AccountId,
 
     fn pay_sorder(_: &<Test as system::Trait>::Hash) { }
 
-    fn close_sorder(_: &Hash, _: &AccountId) { }
+    fn close_sorder(_: &Hash, _: &AccountId, _: &BlockNumber) { }
 }
 
 parameter_types! {

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -521,14 +521,14 @@ fn test_for_half_punish_should_work() {
             used: 0
         });
 
-        // total fee has been punished.
-        set_punishment_in_success_count(&order_id, 90);
-
+        // total fee has been punished. The order has been closed
         assert_eq!(Balances::free_balance(&provider), 190);
         assert_eq!(Market::pledges(&provider), Pledge {
             total: 50,
             used: 0
         });
+        assert!(!<StorageOrders<Test>>::contains_key(&order_id));
+        assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
     });
 }
 
@@ -589,12 +589,13 @@ fn test_for_full_punish_should_work() {
             used: 0
         });
 
-        set_punishment_in_success_count(&order_id, 90);
-
+        // total fee has been punished. The order has been closed
         assert_eq!(Balances::free_balance(&provider), 190);
         assert_eq!(Market::pledges(&provider), Pledge {
             total: 50,
             used: 0
         });
+        assert!(!<StorageOrders<Test>>::contains_key(&order_id));
+        assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
     });
 }

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -599,3 +599,65 @@ fn test_for_full_punish_should_work() {
         assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
     });
 }
+
+#[test]
+fn test_for_close_sorder() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = 0;
+        let file_identifier =
+        hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
+        let provider: u64 = 100;
+        let client: u64 = 0;
+        let file_size = 16; // should less than provider
+        let duration = 10;
+        let fee: u64 = 1;
+        let amount: u64 = 10;
+        let address_info = "ws://127.0.0.1:8855".as_bytes().to_vec();
+        let _ = Balances::make_free_balance_be(&source, 60);
+
+        // 1. Normal flow, aka happy pass 😃
+        let _ = Balances::make_free_balance_be(&provider, 200);
+        assert_ok!(Market::pledge(Origin::signed(provider.clone()), 60));
+        assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), provider,
+            file_identifier.clone(), file_size, duration
+        ));
+
+        let order_id = H256::default();
+        assert_eq!(Market::storage_orders(&order_id).unwrap(), StorageOrder {
+            file_identifier: file_identifier.clone(),
+            file_size: 16,
+            created_on: 50,
+            completed_on: 50,
+            expired_on: 50+10*10,
+            provider,
+            client,
+            amount,
+            status: OrderStatus::Pending
+        });
+
+        Market::close_sorder(&order_id);
+        // storage order has been closed
+        assert_eq!(Balances::free_balance(&provider), 200);
+        assert_eq!(Market::pledges(&provider), Pledge {
+            total: 60,
+            used: 0
+        });
+        assert!(!<StorageOrders<Test>>::contains_key(&order_id));
+        assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
+        // delete it twice would not have bad effect
+        Market::close_sorder(&order_id);
+        assert_eq!(Balances::free_balance(&provider), 200);
+        assert_eq!(Market::pledges(&provider), Pledge {
+            total: 60,
+            used: 0
+        });
+        assert!(!<StorageOrders<Test>>::contains_key(&order_id));
+        assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
+    });
+}

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -71,11 +71,12 @@ impl<T: Trait> Payment<<T as system::Trait>::AccountId,
     }
 
     fn close_sorder(sorder_id: &T::Hash, client: &T::AccountId, complted_on: &BlockNumber) {
-        let ledger = Self::payment_ledgers(&sorder_id).unwrap_or_default();
-        T::Currency::unreserve(
-            &client,
-            ledger.total - ledger.unreserved);
-        <PaymentLedgers<T>>::remove(&sorder_id);
+        if let Some(ledger) = Self::payment_ledgers(&sorder_id) {
+            T::Currency::unreserve(
+                &client,
+                ledger.total - ledger.unreserved);
+            <PaymentLedgers<T>>::remove(&sorder_id);
+        }
 
         let slot_factor = complted_on % T::Frequency::get();
         <SlotPayments<T>>::remove(slot_factor, sorder_id);

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -76,6 +76,7 @@ impl<T: Trait> Payment<<T as system::Trait>::AccountId,
             &client,
             ledger.unreserved);
         <Payments<T>>::remove(&sorder_id);
+        // TODO: Remove slot pay
     }
 }
 

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -69,6 +69,14 @@ impl<T: Trait> Payment<<T as system::Trait>::AccountId,
             }
         }
     }
+
+    fn close_sorder(sorder_id: &T::Hash, client: &T::AccountId) {
+        let ledger = Self::payments(&sorder_id).unwrap_or_default();
+        T::Currency::unreserve(
+            &client,
+            ledger.unreserved);
+        <Payments<T>>::remove(&sorder_id);
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -70,13 +70,15 @@ impl<T: Trait> Payment<<T as system::Trait>::AccountId,
         }
     }
 
-    fn close_sorder(sorder_id: &T::Hash, client: &T::AccountId) {
-        let ledger = Self::payments(&sorder_id).unwrap_or_default();
+    fn close_sorder(sorder_id: &T::Hash, client: &T::AccountId, complted_on: &BlockNumber) {
+        let ledger = Self::payment_ledgers(&sorder_id).unwrap_or_default();
         T::Currency::unreserve(
             &client,
-            ledger.unreserved);
-        <Payments<T>>::remove(&sorder_id);
-        // TODO: Remove slot pay
+            ledger.total - ledger.unreserved);
+        <PaymentLedgers<T>>::remove(&sorder_id);
+
+        let slot_factor = complted_on % T::Frequency::get();
+        <SlotPayments<T>>::remove(slot_factor, sorder_id);
     }
 }
 

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -302,6 +302,8 @@ impl<T: Trait> Module<T> {
             if let Some(provision) = T::MarketInterface::providers(&controller) {
                 for (f_id, order_ids) in provision.file_map.iter() {
                     for order_id in order_ids {
+                        // Do it before updating current work report
+                        T::MarketInterface::maybe_punish_provider(order_id);
                         // Get order status(should exist) and (maybe) change the status
                         let sorder =
                             T::MarketInterface::maybe_get_sorder(order_id).unwrap_or_default();
@@ -441,7 +443,6 @@ impl<T: Trait> Module<T> {
                         sorder.status = OrderStatus::Failed;
                         T::MarketInterface::maybe_set_sorder(order_id, &sorder);
                     }
-                    T::MarketInterface::maybe_punish_provider(order_id);
                 }
 
                 // 3. Return reserved and used

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -298,9 +298,9 @@ impl<T: Trait> Module<T> {
         let workload_map: Vec<(T::AccountId, u128)> = <Identities<T>>::iter().map(|(controller, _)| {
             // a. calculate this controller's order file map
             // TC = O(nm), `n` is stored files number and `m` is corresponding order ids
-            let mut order_files: Vec<(MerkleRoot, T::Hash)> = vec![];
-            let mut punishment_order_ids: Vec<T::Hash> = vec![];
-            let mut overdue_order_ids: Vec<T::Hash> = vec![];
+            let mut success_sorder_files: Vec<(MerkleRoot, T::Hash)> = vec![];
+            let mut ongoing_sorder_ids: Vec<T::Hash> = vec![];
+            let mut overdue_sorder_ids: Vec<T::Hash> = vec![];
             if let Some(provision) = T::MarketInterface::providers(&controller) {
                 for (f_id, order_ids) in provision.file_map.iter() {
                     for order_id in order_ids {
@@ -309,27 +309,27 @@ impl<T: Trait> Module<T> {
                         let sorder =
                             T::MarketInterface::maybe_get_sorder(order_id).unwrap_or_default();
                         if sorder.status == OrderStatus::Success {
-                            order_files.push((f_id.clone(), order_id.clone()))
+                            success_sorder_files.push((f_id.clone(), order_id.clone()))
                         }
+                        ongoing_sorder_ids.push(order_id.clone());
                         if sorder.completed_on >= Self::get_current_block_number() {
-                            overdue_order_ids.push(order_id.clone());
-                        } else {
-                            punishment_order_ids.push(order_id.clone());
+                            // TODO: add extra punishment logic when we close overdue sorder
+                            overdue_sorder_ids.push(order_id.clone());
                         }
                     }
                 }
             }
             // do punishment
-            for order_id in punishment_order_ids {
+            for order_id in ongoing_sorder_ids {
                 T::MarketInterface::maybe_punish_provider(&order_id);
             }
             // close overdue storage order
-            for order_id in overdue_order_ids {
+            for order_id in overdue_sorder_ids {
                 T::MarketInterface::close_sorder(&order_id);
             }
 
             // b. calculate controller's own reserved and used space
-            let (reserved, used) = Self::update_and_get_workload(&controller, &order_files, current_rs);
+            let (reserved, used) = Self::update_and_get_workload(&controller, &success_sorder_files, current_rs);
 
             // c. add to total
             total_used += used;

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -92,6 +92,8 @@ impl market::Payment<<Test as system::Trait>::AccountId,
     }
 
     fn pay_sorder(_: &<Test as system::Trait>::Hash) { }
+
+    fn close_sorder(_: &Hash, _: &AccountId) {}
 }
 
 parameter_types! {

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -93,7 +93,7 @@ impl market::Payment<<Test as system::Trait>::AccountId,
 
     fn pay_sorder(_: &<Test as system::Trait>::Hash) { }
 
-    fn close_sorder(_: &Hash, _: &AccountId) {}
+    fn close_sorder(_: &Hash, _: &AccountId, _: &BlockNumber) { }
 }
 
 parameter_types! {
@@ -191,7 +191,7 @@ pub fn upsert_sorder_to_provider(who: &AccountId, f_id: &MerkleRoot, rd: u8, os:
         expired_on: 0,
         provider: who.clone(),
         client: who.clone(),
-        amount: 0,
+        amount: 10,
         status: os
     };
     if let Some(orders) = file_map.get_mut(f_id) {


### PR DESCRIPTION
Fix #138 Fix #155 Fix #186 

- Add `fn close_sorder` in market Module<T>
- Add `fn close_sorder` in Payment Interface to related payment
- Add `fn close_sorder` in MarketInterface
- In update_identites, `close_sorder` would be invoked if the sorder is overdue.
- Full punishment will invoke `close_sorder`