### PR TITLE
[Market] Fix outdated sorder not close

### DIFF
--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -622,7 +622,6 @@ fn test_for_close_sorder() {
         let _ = Balances::make_free_balance_be(&provider, 200);
         assert_ok!(Market::pledge(Origin::signed(provider.clone()), 60));
         assert_ok!(Market::register(Origin::signed(provider.clone()), address_info.clone(), fee));
-
         assert_ok!(Market::place_storage_order(
             Origin::signed(source), provider,
             file_identifier.clone(), file_size, duration
@@ -642,6 +641,7 @@ fn test_for_close_sorder() {
         });
 
         Market::close_sorder(&order_id);
+
         // storage order has been closed
         assert_eq!(Balances::free_balance(&provider), 200);
         assert_eq!(Market::pledges(&provider), Pledge {
@@ -650,6 +650,13 @@ fn test_for_close_sorder() {
         });
         assert!(!<StorageOrders<Test>>::contains_key(&order_id));
         assert!(!<ProviderPunishments<Test>>::contains_key(&order_id));
+        assert_eq!(Market::providers(&provider).unwrap(), Provision {
+            address_info: address_info.clone(),
+            storage_price: fee,
+            file_map: vec![].into_iter().collect()
+        });
+
+
         // delete it twice would not have bad effect
         Market::close_sorder(&order_id);
         assert_eq!(Balances::free_balance(&provider), 200);

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -147,7 +147,6 @@ decl_module! {
         // this is needed only if you are using events in your module
         fn deposit_event() = default;
 
-
         fn on_initialize(now: T::BlockNumber) -> Weight {
             let now = TryInto::<BlockNumber>::try_into(now).ok().unwrap();
             Self::batch_transfer(now % T::Frequency::get());

--- a/cstrml/tee/src/lib.rs
+++ b/cstrml/tee/src/lib.rs
@@ -315,7 +315,7 @@ impl<T: Trait> Module<T> {
                             success_sorder_files.push((f_id.clone(), order_id.clone()))
                         }
                         ongoing_sorder_ids.push(order_id.clone());
-                        if sorder.completed_on >= Self::get_current_block_number() {
+                        if Self::get_current_block_number() >= sorder.expired_on {
                             // TODO: add extra punishment logic when we close overdue sorder
                             overdue_sorder_ids.push(order_id.clone());
                         }

--- a/cstrml/tee/src/mock.rs
+++ b/cstrml/tee/src/mock.rs
@@ -192,7 +192,7 @@ pub fn upsert_sorder_to_provider(who: &AccountId, f_id: &MerkleRoot, rd: u8, os:
         file_size: 0,
         created_on: 0,
         completed_on: 0,
-        expired_on: 0,
+        expired_on: 350,
         provider: who.clone(),
         client: who.clone(),
         amount: 10,

--- a/cstrml/tee/src/tests.rs
+++ b/cstrml/tee/src/tests.rs
@@ -307,7 +307,7 @@ fn test_for_report_works_success() {
         // prepare sorder
         add_pending_sorder();
 
-        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 0);
+        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 350);
 
         let account: AccountId = Sr25519Keyring::Bob.to_account_id();
         let report_works_info = valid_report_works_info();
@@ -334,7 +334,7 @@ fn test_for_report_works_success() {
                    OrderStatus::Success);
         assert_eq!(Market::storage_orders(Hash::repeat_byte(2)).unwrap_or_default().status,
                    OrderStatus::Success);
-        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 303);
+        assert_eq!(Market::storage_orders(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 653);
     });
 }
 
@@ -568,7 +568,7 @@ fn test_for_wr_check_failed_order() {
         Tee::update_identities();
 
         // Check this 99 order should be failed
-        assert_eq!(Market::storage_orders(Hash::repeat_byte(99)).unwrap_or_default().status,
+        assert_eq!(Market::storage_orders(Hash::repeat_byte(99)).unwrap().status,
                    OrderStatus::Failed);
     });
 }


### PR DESCRIPTION
- Fix outdated sorder not close
- Change deprecated interface `remove_item`(warning under `rustc 1.46.0`)