### PR TITLE
[Dockerize] Fix build script format show wrong under MacOS

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -27,8 +27,8 @@ while getopts ":hp" opt; do
             ;;
     esac
 done
-
-source docker/utils.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/utils.sh
 
 BUILD_DIR="`pwd`"
 DIST_FILE="target/release/crust"

--- a/docker/build_bin.sh
+++ b/docker/build_bin.sh
@@ -46,7 +46,8 @@ while getopts ":hmrpc:" opt; do
     esac
 done
 
-source docker/utils.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/utils.sh
 
 log_info "Using cache dir: $CACHEDIR"
 if [ ! -d $CACHEDIR ]; then

--- a/docker/crust-env/Dockerfile
+++ b/docker/crust-env/Dockerfile
@@ -7,4 +7,4 @@ RUN rustup update ${RUSTUP_TOOLCHAIN}
 RUN rustup update stable
 RUN rustup target add wasm32-unknown-unknown --toolchain ${RUSTUP_TOOLCHAIN}
 RUN rustup default ${RUSTUP_TOOLCHAIN}
-RUN apt-get update && apt-get install -y llvm clang libclang-de
+RUN apt-get update && apt-get install -y llvm clang libclang-dev

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -1,5 +1,5 @@
 function echo_c {
-    echo -e "\e[1;$1m$2\e[0m"
+    printf "\033[0;$1m$2\033[0m\n"
 }
 
 function log_info {


### PR DESCRIPTION
logging function should be colorful on macos.
use the relative path to find utils.sh
fix a typo in env dockerfile

Signed-off-by: pangwa <pangwa@gmail.com>