### PR TITLE
[GPoS] Change stake limit calculation strategy

### DIFF
--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -210,6 +210,7 @@ parameter_types! {
     pub const SessionsPerEra: SessionIndex = 3;
     pub const BondingDuration: EraIndex = 3;
     pub const MaxNominatorRewardedPerValidator: u32 = 64;
+    pub const SPowerRatio: u128 = 2_500;
 }
 impl Trait for Test {
     type Currency = balances::Module<Self>;
@@ -225,6 +226,7 @@ impl Trait for Test {
     type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
     type SessionInterface = Self;
     type TeeInterface = Self;
+    type SPowerRatio = SPowerRatio;
 }
 
 pub struct ExtBuilder {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -309,6 +309,8 @@ parameter_types! {
     pub const BondingDuration: staking::EraIndex = 28;
     // 28 eras in which slashes can be cancelled (14 hours).
     pub const SlashDeferDuration: staking::EraIndex = 28;
+    // 80_000 * CRUs / TB, since we treat 1 TB = 1_000_000_000_000, so the ratio = `80_000`
+    pub const SPowerRatio: u128 = 80_000;
 }
 
 impl staking::Trait for Runtime {
@@ -328,6 +330,7 @@ impl staking::Trait for Runtime {
     type SlashCancelOrigin = system::EnsureRoot<Self::AccountId>;
     type SessionInterface = Self;
     type TeeInterface = Self;
+    type SPowerRatio = SPowerRatio;
 }
 
 parameter_types! {


### PR DESCRIPTION
### Summary
SPowerRatio(storage power ratio) is a key value inside Crust Network, we may divided into 2 phases for calculating this value:
- 1st phase: mapping just 1 terabytes into fixed currency(Maxwell <this PR> is `80_000`, Olympus may will be `30`)
- 2nd phase: using formula shows in the economy whitepaper with `R/R'` stuff

### About this PR
1. Add `SPowerRatio`;
2. Change `stake_limit_of`;
3. Break tests with compatible with new `stake_limit_of` func;