### PR TITLE
[GPoS] support MaxGuarantorRewardedPerValidator

### DIFF
--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -391,9 +391,9 @@ pub trait Trait: frame_system::Trait {
 
     /// The maximum number of nominators rewarded for each validator.
     ///
-    /// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
+    /// For each validator only the `$MaxGuarantorRewardedPerValidator` biggest stakers can claim
     /// their reward. This used to limit the i/o cost for the nominator payout.
-    type MaxNominatorRewardedPerValidator: Get<u32>;
+    type MaxGuarantorRewardedPerValidator: Get<u32>;
 
     /// Number of eras that slashes are deferred by, after computation. This
     /// should be less than the bonding duration. Set to 0 if slashes should be
@@ -477,7 +477,7 @@ decl_storage! {
         /// Clipped Exposure of validator at era.
         ///
         /// This is similar to [`ErasStakers`] but number of nominators exposed is reduced to the
-        /// `T::MaxNominatorRewardedPerValidator` biggest stakers.
+        /// `T::MaxGuarantorRewardedPerValidator` biggest stakers.
         /// (Note: the field `total` and `own` of the exposure remains unchanged).
         /// This is used to limit the i/o cost for the nominator payout.
         ///
@@ -703,9 +703,9 @@ decl_module! {
 
         /// The maximum number of nominators rewarded for each validator.
         ///
-        /// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
+        /// For each validator only the `$MaxGuarantorRewardedPerValidator` biggest stakers can claim
         /// their reward. This used to limit the i/o cost for the nominator payout.
-        const MaxNominatorRewardedPerValidator: u32 = T::MaxNominatorRewardedPerValidator::get();
+        const MaxGuarantorRewardedPerValidator: u32 = T::MaxGuarantorRewardedPerValidator::get();
 
 
         type Error = Error<T>;
@@ -1309,7 +1309,7 @@ decl_module! {
         /// Pay out all the stakers behind a single validator for a single era.
         ///
         /// - `validator_stash` is the stash account of the validator. Their nominators, up to
-        ///   `T::MaxNominatorRewardedPerValidator`, will also receive their rewards.
+        ///   `T::MaxGuarantorRewardedPerValidator`, will also receive their rewards.
         /// - `era` may be any era between `[current_era - history_depth; current_era]`.
         ///
         /// The origin of this call must be _Signed_. Any account can call this function, even if
@@ -1962,7 +1962,7 @@ impl<T: Trait> Module<T> {
             <ErasStakers<T>>::insert(&current_era, &v_stash, new_exposure.clone());
             let exposure_total = new_exposure.total;
             let mut exposure_clipped = new_exposure;
-            let clipped_max_len = T::MaxNominatorRewardedPerValidator::get() as usize;
+            let clipped_max_len = T::MaxGuarantorRewardedPerValidator::get() as usize;
             if exposure_clipped.others.len() > clipped_max_len {
                 exposure_clipped.others.sort_by(|a, b| a.value.cmp(&b.value).reverse());
                 exposure_clipped.others.truncate(clipped_max_len);

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -390,10 +390,10 @@ pub trait Trait: frame_system::Trait {
     type BondingDuration: Get<EraIndex>;
 
     /// The maximum number of nominators rewarded for each validator.
-	///
-	/// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
-	/// their reward. This used to limit the i/o cost for the nominator payout.
-	type MaxNominatorRewardedPerValidator: Get<u32>;
+    ///
+    /// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
+    /// their reward. This used to limit the i/o cost for the nominator payout.
+    type MaxNominatorRewardedPerValidator: Get<u32>;
 
     /// Number of eras that slashes are deferred by, after computation. This
     /// should be less than the bonding duration. Set to 0 if slashes should be
@@ -475,17 +475,17 @@ decl_storage! {
             => Exposure<T::AccountId, BalanceOf<T>>;
 
         /// Clipped Exposure of validator at era.
-		///
-		/// This is similar to [`ErasStakers`] but number of nominators exposed is reduced to the
-		/// `T::MaxNominatorRewardedPerValidator` biggest stakers.
-		/// (Note: the field `total` and `own` of the exposure remains unchanged).
-		/// This is used to limit the i/o cost for the nominator payout.
-		///
-		/// This is keyed fist by the era index to allow bulk deletion and then the stash account.
-		///
-		/// Is it removed after `HISTORY_DEPTH` eras.
-		/// If stakers hasn't been set or has been removed then empty exposure is returned.
-		pub ErasStakersClipped get(fn eras_stakers_clipped):
+        ///
+        /// This is similar to [`ErasStakers`] but number of nominators exposed is reduced to the
+        /// `T::MaxNominatorRewardedPerValidator` biggest stakers.
+        /// (Note: the field `total` and `own` of the exposure remains unchanged).
+        /// This is used to limit the i/o cost for the nominator payout.
+        ///
+        /// This is keyed fist by the era index to allow bulk deletion and then the stash account.
+        ///
+        /// Is it removed after `HISTORY_DEPTH` eras.
+        /// If stakers hasn't been set or has been removed then empty exposure is returned.
+        pub ErasStakersClipped get(fn eras_stakers_clipped):
         double_map hasher(twox_64_concat) EraIndex, hasher(twox_64_concat) T::AccountId
         => Exposure<T::AccountId, BalanceOf<T>>;
             
@@ -702,10 +702,10 @@ decl_module! {
         const BondingDuration: EraIndex = T::BondingDuration::get();
 
         /// The maximum number of nominators rewarded for each validator.
-		///
-		/// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
-		/// their reward. This used to limit the i/o cost for the nominator payout.
-		const MaxNominatorRewardedPerValidator: u32 = T::MaxNominatorRewardedPerValidator::get();
+        ///
+        /// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
+        /// their reward. This used to limit the i/o cost for the nominator payout.
+        const MaxNominatorRewardedPerValidator: u32 = T::MaxNominatorRewardedPerValidator::get();
 
 
         type Error = Error<T>;

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -226,6 +226,7 @@ impl Trait for Test {
     type Slash = ();
     type Reward = ();
     type SessionsPerEra = SessionsPerEra;
+    type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
     type BondingDuration = BondingDuration;
     type SlashDeferDuration = SlashDeferDuration;
     type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -213,7 +213,7 @@ impl swork::Trait for Test {
 parameter_types! {
     pub const SessionsPerEra: SessionIndex = 3;
     pub const BondingDuration: EraIndex = 3;
-    pub const MaxNominatorRewardedPerValidator: u32 = 4;
+    pub const MaxGuarantorRewardedPerValidator: u32 = 4;
     pub const SPowerRatio: u128 = 2_500;
 }
 impl Trait for Test {
@@ -226,7 +226,7 @@ impl Trait for Test {
     type Slash = ();
     type Reward = ();
     type SessionsPerEra = SessionsPerEra;
-    type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+    type MaxGuarantorRewardedPerValidator = MaxGuarantorRewardedPerValidator;
     type BondingDuration = BondingDuration;
     type SlashDeferDuration = SlashDeferDuration;
     type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -213,7 +213,7 @@ impl swork::Trait for Test {
 parameter_types! {
     pub const SessionsPerEra: SessionIndex = 3;
     pub const BondingDuration: EraIndex = 3;
-    pub const MaxNominatorRewardedPerValidator: u32 = 64;
+    pub const MaxNominatorRewardedPerValidator: u32 = 4;
     pub const SPowerRatio: u128 = 2_500;
 }
 impl Trait for Test {

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -252,6 +252,15 @@ fn rewards_should_work() {
                     others: vec![IndividualExposure { who: 2, value: 500 }],
                 },
             );
+            <ErasStakersClipped<Test>>::insert(
+                0,
+                &11,
+                Exposure {
+                    own: 500,
+                    total: 1000,
+                    others: vec![IndividualExposure { who: 2, value: 500 }],
+                },
+            );
 
             <Payee<Test>>::insert(&2, RewardDestination::Stash);
             assert_eq!(Staking::payee(2), RewardDestination::Stash);
@@ -1316,6 +1325,15 @@ fn validator_payment_prefs_work() {
                 others: vec![IndividualExposure { who: 2, value: 500 }],
             },
         );
+        <ErasStakersClipped<Test>>::insert(
+            0,
+            &11,
+            Exposure {
+                own: 500, // equal division indicates that the reward will be equally divided among validator and guarantor.
+                total: 1000,
+                others: vec![IndividualExposure { who: 2, value: 500 }],
+            },
+        );
         <ErasValidatorPrefs<Test>>::insert(
             0,
             &11,
@@ -2302,6 +2320,16 @@ fn reward_validator_slashing_validator_doesnt_overflow() {
             },
         );
 
+        <ErasStakersClipped<Test>>::insert(
+            0,
+            &11,
+            Exposure {
+                total: stake,
+                own: stake,
+                others: vec![],
+            },
+        );
+
         <ErasStakingPayout<Test>>::insert(
             0,
             reward_slash
@@ -2325,6 +2353,19 @@ fn reward_validator_slashing_validator_doesnt_overflow() {
         )
         .unwrap();
         <ErasStakers<Test>>::insert(
+            0,
+            &11,
+            Exposure {
+                total: stake,
+                own: 1,
+                others: vec![IndividualExposure {
+                    who: 2,
+                    value: stake - 1,
+                }],
+            },
+        );
+
+        <ErasStakersClipped<Test>>::insert(
             0,
             &11,
             Exposure {
@@ -4004,12 +4045,14 @@ fn era_clean_should_work() {
             assert!(<ErasStakingPayout<Test>>::contains_key(0));
             assert!(<ErasTotalStakes<Test>>::contains_key(0));
             assert!(<ErasStakers<Test>>::contains_key(0, 21));
+            assert!(<ErasStakersClipped<Test>>::contains_key(0, 21));
             assert!(<ErasValidatorPrefs<Test>>::contains_key(0, 21));
             start_era(85, true);
             assert!(!<ErasStakingPayout<Test>>::contains_key(0));
             assert!(!<ErasAuthoringPayout<Test>>::contains_key(0, 21));
             assert!(!<ErasTotalStakes<Test>>::contains_key(0));
             assert!(!<ErasStakers<Test>>::contains_key(0, 21));
+            assert!(!<ErasStakersClipped<Test>>::contains_key(0, 21));
             assert!(!<ErasValidatorPrefs<Test>>::contains_key(0, 21));
         });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -379,6 +379,8 @@ parameter_types! {
     pub const SlashDeferDuration: staking::EraIndex = 28;
     // 80_000 * CRUs / TB, since we treat 1 TB = 1_000_000_000_000, so the ratio = `80_000`
     pub const SPowerRatio: u128 = 80_000;
+    // 64 guarantors for one validator.
+    pub const MaxNominatorRewardedPerValidator: u32 = 64;
 }
 
 impl staking::Trait for Runtime {
@@ -394,6 +396,7 @@ impl staking::Trait for Runtime {
     type SessionsPerEra = SessionsPerEra;
     type BondingDuration = BondingDuration;
     type SlashDeferDuration = SlashDeferDuration;
+    type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 
     // A majority of the council can cancel the slash.
     type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -380,7 +380,7 @@ parameter_types! {
     // 80_000 * CRUs / TB, since we treat 1 TB = 1_000_000_000_000, so the ratio = `80_000`
     pub const SPowerRatio: u128 = 80_000;
     // 64 guarantors for one validator.
-    pub const MaxNominatorRewardedPerValidator: u32 = 64;
+    pub const MaxGuarantorRewardedPerValidator: u32 = 64;
 }
 
 impl staking::Trait for Runtime {
@@ -396,7 +396,7 @@ impl staking::Trait for Runtime {
     type SessionsPerEra = SessionsPerEra;
     type BondingDuration = BondingDuration;
     type SlashDeferDuration = SlashDeferDuration;
-    type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+    type MaxGuarantorRewardedPerValidator = MaxGuarantorRewardedPerValidator;
 
     // A majority of the council can cancel the slash.
     type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;


### PR DESCRIPTION
Fix #253 

Still include era stakers clipped to avoid potential attack. Some one can create several accounts(A,B,C,D...) to be garantors. Each garantor would just garantee a small number of CRU to one validator(X). Then this validator X cannot be guranteed anymore, which doesn't make sense.