### PR TITLE
Add log and debug for runtimes

### DIFF
--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -311,7 +311,7 @@ decl_module! {
                     // Update merchant
                     debug::info!(
                         target: "market",
-                        "Change {:?}'s address information and storage price.",
+                        "🏢 Change {:?}'s address information and storage price.",
                         who
                     );
                     minfo.address_info = address_info;
@@ -320,7 +320,7 @@ decl_module! {
                     // New merchant
                     debug::info!(
                         target: "market",
-                        "New merchant {:?} is registered.",
+                        "🏢 New merchant {:?} is registered.",
                         who
                     );
                     *maybe_minfo = Some(MerchantInfo {
@@ -440,7 +440,7 @@ decl_module! {
             if pledge.total.is_zero() {
                 debug::info!(
                     target: "market",
-                    "Remove pledge for {:?}",
+                    "🏢 Remove pledge for {:?}",
                     who
                 );
                 <Pledges<T>>::remove(&who);
@@ -517,7 +517,7 @@ decl_module! {
                 // a. update pledge
                 debug::info!(
                     target: "market",
-                    "Update pledge for {:?} and order ids for {:?}",
+                    "🏢 Update pledge for {:?} and order ids for {:?}",
                     merchant,
                     who
                 );
@@ -575,7 +575,7 @@ impl<T: Trait> Module<T> {
                     so.status == OrderStatus::Success {
                         debug::info!(
                             target: "market",
-                            "Start payment for sorder {:?}",
+                            "🏢 Start payment for sorder {:?}",
                             order_id
                         );
                         T::Payment::pay_sorder(order_id);
@@ -662,7 +662,7 @@ impl<T: Trait> Module<T> {
             if !T::Payment::reserve_sorder(&order_id, client, amount) {
                 debug::debug!(
                     target: "market",
-                    "Cannot reserve currency for sorder {:?}",
+                    "🏢 Cannot reserve currency for sorder {:?}",
                     order_id
                 );
                 return None
@@ -677,7 +677,7 @@ impl<T: Trait> Module<T> {
                 if let Some(minfo) = maybe_minfo {
                     debug::info!(
                         target: "market",
-                        "Add sorder {:?} into merchant {:?}",
+                        "🏢 Add sorder {:?} into merchant {:?}",
                         order_id,
                         merchant
                     );
@@ -755,7 +755,7 @@ impl<T: Trait> Module<T> {
     ) {
         debug::info!(
             target: "market",
-            "Update pledge for merchant {:?}",
+            "🏢 Update pledge for merchant {:?}",
             merchant
         );
         // 1. Set lock

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -517,11 +517,11 @@ decl_module! {
                 });
                 // b. Add `order_id` to client orders
                 <Clients<T>>::mutate(&who, file_alias, |maybe_client_orders| {
-                    if let Some(client_order) = maybe_client_orders {    
-                        client_order.push(order_id.clone());    
-                    } else {    
-                        *maybe_client_orders = Some(vec![order_id.clone()])    
-                    }    
+                    if let Some(client_order) = maybe_client_orders {
+                        client_order.push(order_id.clone());
+                    } else {
+                        *maybe_client_orders = Some(vec![order_id.clone()])
+                    }
                 });
                 // c. emit storage order success event
                 Self::deposit_event(RawEvent::StorageOrderSuccess(who, storage_order));

--- a/cstrml/payment/src/lib.rs
+++ b/cstrml/payment/src/lib.rs
@@ -162,7 +162,7 @@ impl<T: Trait> Module<T> {
     pub fn batch_transfer(slot_factor: BlockNumber) {
         debug::info!(
             target: "payment",
-            "Batch transfer for block number {:?}.",
+            "💰 Batch transfer for block number {:?}.",
             slot_factor
         );
         for (sorder_id, slot_value) in <SlotPayments<T>>::iter_prefix(slot_factor) {
@@ -222,7 +222,7 @@ impl<T: Trait> Module<T> {
                     // TODO: Double check this behavior since it should be a workaround. Maybe a special status is better?
                     debug::debug!(
                         target: "payment",
-                        "Reserve the currency  due to unknow reason for sorder {:?}.",
+                        "💰 Reserve the currency  due to unknow reason for sorder {:?}.",
                         sorder_id
                     );
                     let _ = T::Currency::reserve(&client, real_amount);
@@ -236,7 +236,7 @@ impl<T: Trait> Module<T> {
             _ => {
                 debug::info!(
                     target: "payment",
-                    "Fail to transfer currency due to failed status for sorder {:?}.",
+                    "💰 Fail to transfer currency due to failed status for sorder {:?}.",
                     sorder_id
                 );
             }

--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -15,7 +15,7 @@ mod tests;
 use codec::{Decode, Encode, HasCompact};
 use frame_support::{
     decl_module, decl_event, decl_storage, ensure, decl_error,
-    storage::IterableStorageMap,
+    storage::IterableStorageMap, debug,
     weights::{Weight, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
     traits::{
         Currency, LockIdentifier, LockableCurrency, WithdrawReasons, OnUnbalanced, Imbalance, Get,
@@ -1387,6 +1387,12 @@ impl<T: Trait> Module<T> {
     ) -> Option<Guarantee<T::AccountId, BalanceOf<T>>> {
         // 1. Already guaranteed
         if let Some(guarantee) = Self::guarantors(g_stash) {
+            debug::info!(
+                target: "staking",
+                "📈 Increase votes to validator {:?} from gurantor {:?}.",
+                v_stash,
+                g_stash
+            );
             let remains = bonded.saturating_sub(guarantee.total);
             let real_votes = remains.min(votes);
             let new_total = guarantee.total.saturating_add(real_votes);
@@ -1394,6 +1400,11 @@ impl<T: Trait> Module<T> {
             let mut update = false;
 
             if real_votes <= Zero::zero() {
+                debug::info!(
+                    target: "staking",
+                    "📈 Staking limit of validator {:?} is zero.",
+                    v_stash
+                );
                 return None
             }
 
@@ -1429,6 +1440,12 @@ impl<T: Trait> Module<T> {
 
         // 2. New guarantee
         } else {
+            debug::info!(
+                target: "staking",
+                "📈 New votes to validator {:?} from gurantor {:?}",
+                v_stash,
+                g_stash
+            );
             let real_votes = bonded.min(votes);
             let new_total = real_votes;
 
@@ -1667,6 +1684,11 @@ impl<T: Trait> Module<T> {
             *s = Some(s.map(|s| s + 1).unwrap_or(0));
             s.unwrap()
         });
+        debug::info!(
+            target: "staking",
+            "📈 Plan a new era {:?}",
+            current_era
+        );
         ErasStartSessionIndex::insert(&current_era, &start_session_index);
 
         // Clean old era information.
@@ -1725,7 +1747,11 @@ impl<T: Trait> Module<T> {
             });
             new_index
         });
-
+        debug::info!(
+            target: "staking",
+            "📈 Start the era {:?}",
+            active_era
+        );
         let bonding_duration = T::BondingDuration::get();
 
         BondedEras::mutate(|bonded| {
@@ -1756,11 +1782,21 @@ impl<T: Trait> Module<T> {
     /// Compute payout for era.
     fn end_era(active_era: ActiveEraInfo, _session_index: SessionIndex) {
         // Note: active_era_start can be None if end era is called during genesis config.
+        debug::info!(
+            target: "staking",
+            "📈 End the era {:?}",
+            active_era.index
+        );
         if let Some(active_era_start) = active_era.start {
             let now_as_millis_u64 = T::UnixTime::now().as_millis().saturated_into::<u64>();
 
             let era_duration = now_as_millis_u64 - active_era_start;
             if !era_duration.is_zero() {
+                debug::info!(
+                    target: "staking",
+                    "📈 Calculate rewards for the era {:?}",
+                    active_era.index
+                );
                 let active_era_index = active_era.index.clone();
                 let points = <ErasRewardPoints<T>>::get(&active_era_index);
                 let total_authoring_payout = Self::authoring_rewards_in_era();
@@ -1791,6 +1827,11 @@ impl<T: Trait> Module<T> {
 
         /// Clear all era information for given era.
     fn clear_era_information(era_index: EraIndex) {
+        debug::info!(
+            target: "staking",
+            "📈 Clear old era {:?} information.",
+            era_index
+        );
         <ErasStakers<T>>::remove_prefix(era_index);
         <ErasStakersClipped<T>>::remove_prefix(era_index);
         <ErasValidatorPrefs<T>>::remove_prefix(era_index);
@@ -1884,6 +1925,12 @@ impl<T: Trait> Module<T> {
         // II. Construct and fill in the V/G graph
         // TC is O(V + G*1), V means validator's number, G means guarantor's number
         // DB try is 2
+
+        debug::info!(
+            target: "staking",
+            "📈 Construct and fill in the V/G graph for the era {:?}.",
+            current_era
+        );
         let mut vg_graph: BTreeMap<T::AccountId, Vec<IndividualExposure<T::AccountId, BalanceOf<T>>>> =
             <Validators<T>>::iter().map(|(v_stash, _)|
                 (v_stash, Vec::<IndividualExposure<T::AccountId, BalanceOf<T>>>::new())
@@ -1915,6 +1962,11 @@ impl<T: Trait> Module<T> {
         // 2. Get `ErasValidatorPrefs`
         // 3. Get `total_valid_stakes`
         // 4. Fill in `validator_stakes`
+        debug::info!(
+            target: "staking",
+            "📈 Build the erasStakers for the era {:?}.",
+            current_era
+        );
         let mut eras_total_stakes: BalanceOf<T> = Zero::zero();
         let mut validators_stakes: Vec<(T::AccountId, u128)> = vec![];
         for (v_stash, voters) in vg_graph.iter() {
@@ -1979,6 +2031,11 @@ impl<T: Trait> Module<T> {
         }
 
         // IV. TopDown Election Algorithm with Randomlization
+        debug::info!(
+            target: "staking",
+            "📈 Validators election for the era {:?}.",
+            current_era
+        );
         let to_elect = (Self::validator_count() as usize).min(validators_stakes.len());
 
         // If there's no validators, be as same as little validators

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -193,7 +193,7 @@ decl_module! {
             ensure_root(origin)?;
             debug::info!(
                 target: "swork",
-                "Set new Code and ABExpire for swork."
+                "🔒 Set new Code and ABExpire for swork."
             );
             <Code>::put(new_code);
             <ABExpire<T>>::put(expire_block);
@@ -285,7 +285,7 @@ decl_module! {
             if Self::reported_in_slot(&curr_pk, slot) {
                 debug::info!(
                     target: "swork",
-                    "Already reported with same pub key {:?} in the same slot {:?}.",
+                    "🔒 Already reported with same pub key {:?} in the same slot {:?}.",
                     curr_pk,
                     slot
                 );
@@ -303,7 +303,7 @@ decl_module! {
             if is_ab_upgrade {
                 debug::info!(
                     target: "swork",
-                    "Do AB upgrade."
+                    "🔒 Do AB upgrade."
                 );
                 // 4.1 Previous pk should already reported works
                 let maybe_prev_wr = Self::work_reports(&ab_upgrade_pk);
@@ -415,7 +415,7 @@ impl<T: Trait> Module<T> {
 
         debug::info!(
             target: "swork",
-            "Loop all identities and update the workload map for slot {:?}",
+            "🔒 Loop all identities and update the workload map for slot {:?}",
             reported_rs
         );
         // 2. Loop all identities and get the workload map
@@ -445,7 +445,7 @@ impl<T: Trait> Module<T> {
         // 4. Update stake limit for every reporter
         debug::info!(
             target: "swork",
-            "Update stake limit for all reporters."
+            "🔒 Update stake limit for all reporters."
         );
         for (reporter, own_workload) in workload_map {
             T::Works::report_works(&reporter, own_workload, total_workload);
@@ -520,7 +520,7 @@ impl<T: Trait> Module<T> {
             if old_wr.report_slot < report_slot - REPORT_SLOT {
                 debug::info!(
                     target: "swork",
-                    "Resume reporting and set sorder status to success for reporter {:?}",
+                    "🔒 Resume reporting and set sorder status to success for reporter {:?}",
                     reporter
                 );
                 let old_files: Vec<(MerkleRoot, u64)> = old_wr.files.into_iter().collect();
@@ -569,7 +569,7 @@ impl<T: Trait> Module<T> {
         if !ab_upgrade_pk.is_empty() {
             debug::info!(
                 target: "swork",
-                "Chill old identity, id_bond and work report for reporter {:?}.",
+                "🔒 Chill old identity, id_bond and work report for reporter {:?}.",
                 reporter
             );
             Self::chill(reporter, ab_upgrade_pk);
@@ -613,7 +613,7 @@ impl<T: Trait> Module<T> {
                     // 3. Or invalid
                     debug::debug!(
                         target: "swork",
-                        "Invalid file id {:?} for reporter {:?}.",
+                        "🔒 Invalid file id {:?} for reporter {:?}.",
                         f_id,
                         reporter
                     );
@@ -648,7 +648,7 @@ impl<T: Trait> Module<T> {
         // Or nope, idk wtf? 🙂
         debug::debug!(
             target: "swork",
-            "No workload for reporter {:?} in slot {:?}",
+            "🔒 No workload for reporter {:?} in slot {:?}",
             reporter,
             current_rs
         );


### PR DESCRIPTION
Fix #235

**Log Levels**
`all`: enable all log level.
`trace`: Lowest. General trace log.
`debug`: Used for debug.
`info`: Normal message.
`warn`: Something might be abnormal.
`error`: Something might be wrong.
`fatal`: Something is wrong.
`off`: off the log.

Default level should be `info`. We use `info` to prompt the message that user might have interests. `debug` is used for abnormal path. `trace` is used for normal path.