### PR TITLE
[MPoW] Preserve IdBonds even if pub key list is empty

### DIFF
--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -563,9 +563,6 @@ impl<T: Trait> Module<T> {
             &who,
             |bonds| bonds.retain(|bond| bond != &pk)
         );
-        if Self::id_bonds(&who).is_empty() {
-            <IdBonds<T>>::remove(&who);
-        }
 
         // 4. Remove from `reported_in_slot`
         ReportedInSlot::remove_prefix(&pk);

--- a/cstrml/swork/src/tests.rs
+++ b/cstrml/swork/src/tests.rs
@@ -314,7 +314,7 @@ fn chill_idbond_should_work() {
                 )
             );
             assert!(!Identities::contains_key(legal_pk.clone()));
-            assert!(!<IdBonds<Test>>::contains_key(applier.clone()));
+            assert!(<IdBonds<Test>>::contains_key(applier.clone()));
         });
 }
 


### PR DESCRIPTION
Fix #340 