### PR TITLE
New DSM Mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "cstrml-balances",
  "cstrml-candy",
  "cstrml-market",
+ "cstrml-market-v2",
  "cstrml-staking",
  "cstrml-swork",
  "frame-benchmarking",
@@ -1111,6 +1112,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstrml-market-v2"
+version = "0.10.0"
+dependencies = [
+ "cst-primitives",
+ "cstrml-balances",
+ "cstrml-swork",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "cstrml-staking"
 version = "0.10.0"
 dependencies = [
@@ -1144,6 +1165,7 @@ dependencies = [
  "cst-primitives",
  "cstrml-balances",
  "cstrml-market",
+ "cstrml-market-v2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -7386,9 +7408,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.6"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
+checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     'cstrml/staking',
     'cstrml/swork',
     'cstrml/market',
+    'cstrml/market_v2',
     'runtime',
     'rpc',
     'node',

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -148,7 +148,7 @@ impl Trait for Test {
     type CurrencyToBalance = CurrencyToVoteHandler;
     type Event = ();
     type Randomness = TestRandomness;
-    type OrderInspector = TestOrderInspector;
+    type OrderInspector = Swork;
     type MinimumStoragePrice = MinimumStoragePrice;
     type MinimumSorderDuration = MinimumSorderDuration;
     type ClaimLimit = TestClaimLimit;

--- a/cstrml/market_v2/Cargo.toml
+++ b/cstrml/market_v2/Cargo.toml
@@ -50,3 +50,4 @@ hex = '0.4.2'
 swork = { version = "0.10.0", package = 'cstrml-swork', path = '../swork' }
 balances = { version = "0.10.0", package = 'cstrml-balances', path = '../balances' }
 frame-benchmarking = { version = '2.0.0' }
+keyring = { package = "sp-keyring", version = '2.0.0' }

--- a/cstrml/market_v2/Cargo.toml
+++ b/cstrml/market_v2/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "cstrml-market-v2"
+version = "0.10.0"
+authors = ["crustio"]
+edition = "2018"
+license = "GPL-3.0"
+homepage = "https://crust.network"
+repository = "https://github.com/crustio/crust/"
+
+[dependencies]
+# third party dependencies
+codec = { default-features = false, package = 'parity-scale-codec', version = '1.3.4', features = ["derive"] }
+serde = { optional = true, version = '1.0.106' }
+serde_json = "1.0.51"
+
+# substrate frames
+frame-system = { default-features = false, version = '2.0.0' }
+frame-support = { default-features = false, version = '2.0.0' }
+
+# substrate primitives
+sp-core = { default-features = false, version = '2.0.0' }
+sp-io = { default-features = false, version = '2.0.0' }
+sp-runtime = { default-features = false, version = '2.0.0' }
+sp-std = { default-features = false, version = '2.0.0' }
+
+frame-benchmarking = { version = '2.0.0', default-features = false, optional = true }
+
+# crust runtime modules
+primitives = { version = "0.10.0", package = 'cst-primitives', path = '../../primitives', default-features = false }
+
+[features]
+default = ['std']
+std = [
+    'serde',
+    'codec/std',
+    'frame-support/std',
+    'sp-core/std',
+    'sp-io/std',
+    'sp-runtime/std',
+    'sp-std/std',
+    'frame-system/std',
+    'primitives/std',
+]
+runtime-benchmarks = [
+    "frame-benchmarking",
+]
+
+[dev-dependencies]
+hex = '0.4.2'
+swork = { version = "0.10.0", package = 'cstrml-swork', path = '../swork' }
+balances = { version = "0.10.0", package = 'cstrml-balances', path = '../balances' }
+frame-benchmarking = { version = '2.0.0' }

--- a/cstrml/market_v2/src/lib.rs
+++ b/cstrml/market_v2/src/lib.rs
@@ -1,0 +1,823 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(option_result_contains)]
+
+use codec::{Decode, Encode};
+use frame_support::{
+    decl_event, decl_module, decl_storage, decl_error,
+    dispatch::DispatchResult, ensure,
+    storage::migration::remove_storage_prefix,
+    traits::{
+        Currency, ReservableCurrency, Get, ExistenceRequirement::AllowDeath,
+    },
+    weights::Weight
+};
+use sp_std::{prelude::*, convert::TryInto, collections::btree_set::BTreeSet};
+use frame_system::{self as system, ensure_signed};
+use sp_runtime::{
+    Perbill, ModuleId,
+    traits::{Zero, CheckedMul, Convert, AccountIdConversion, Saturating}
+};
+
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+use primitives::{
+    MerkleRoot, BlockNumber,
+    traits::{TransferrableCurrency, MarketInterface, SworkerInterface}, SworkerAnchor
+};
+
+pub(crate) const LOG_TARGET: &'static str = "market";
+
+#[macro_export]
+macro_rules! log {
+    ($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+        frame_support::debug::$level!(
+            target: crate::LOG_TARGET,
+            $patter $(, $values)*
+        )
+    };
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct FileInfo<AccountId, Balance> {
+    // The ordered file size, which declare by user
+    pub file_size: u64,
+    // The block number when the file goes invalide
+    pub expired_on: BlockNumber,
+    // The last block number when the file's amount is claimed
+    pub claimed_at: BlockNumber,
+    // The file value
+    pub amount: Balance,
+    // The count of replica that user wants
+    pub expected_replica_count: u32,
+    // The count of valid replica each report slot
+    pub reported_replica_count: u32,
+    // The replica list
+    // TODO: restrict the length of this replica
+    pub replicas: Vec<Replica<AccountId>>
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct Replica<AccountId> {
+    // Controller account
+    pub who: AccountId,
+    // The last bloch number when the node reported works
+    pub valid_at: BlockNumber,
+    // The anchor associated to the node mapping with file
+    pub anchor: SworkerAnchor,
+}
+
+/// According to the definition, we should put this one into swork pallet.
+/// However, in consideration of performance,
+/// we put this in market to avoid too many keys in storage
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct UsedInfo {
+    // The size of used value in MPoW
+    pub used_size: u64,
+    // Anchors which is counted as contributor for this file
+    pub anchors: BTreeSet<SworkerAnchor>
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct MerchantLedger<Balance> {
+    // The current reward amount.
+    pub reward: Balance,
+    // The total pledge amount
+    pub pledge: Balance
+}
+
+type BalanceOf<T> =
+    <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
+
+impl<T: Trait> MarketInterface<<T as system::Trait>::AccountId> for Module<T>
+{
+    /// Upsert new replica
+    /// Accept id(who, anchor), cid, valid_at and maybe_member
+    /// Returns whether this id is counted to a group/itself's stake limit
+    fn upsert_replicas(who: &<T as system::Trait>::AccountId, cid: &MerkleRoot, anchor: &SworkerAnchor, valid_at: BlockNumber, maybe_members: &Option<BTreeSet<<T as system::Trait>::AccountId>>) -> bool {
+        // `is_counted` is a concept in swork-side, which means if this `cid`'s `used` size is counted by `(who, anchor)`
+        // if the file doesn't exist(aka. is_counted == false), return false(doesn't increase used size) cause it's junk.
+        // if the file exist, is_counted == true, will change it later.
+        let mut is_counted = <Files<T>>::get(cid).is_some();
+        if let Some((mut file_info, mut used_info)) = <Files<T>>::get(cid) {
+            
+            // 1. Check if the file is stored by other members
+            if let Some(members) = maybe_members {
+                for replica in file_info.replicas.iter() {
+                    if used_info.anchors.contains(&replica.anchor) && members.contains(&replica.who) {
+                        if T::SworkerInterface::check_anchor(&replica.who, &replica.anchor) {
+                            // duplicated in group and set is_counted to false
+                            is_counted = false;
+                        }
+                    }
+                }
+            }
+
+            // 2. Prepare new replica info
+            let new_replica = Replica {
+                who: who.clone(),
+                valid_at,
+                anchor: anchor.clone(),
+            };
+            file_info.reported_replica_count += 1;
+            Self::insert_replica(&mut file_info, new_replica);
+
+            // 3. Update used_info
+            if is_counted {
+                used_info.anchors.insert(anchor.clone());
+            };
+
+            // 4. The first join the 
+            let curr_bn = Self::get_current_block_number();
+            if file_info.replicas.len() == 1 {
+                file_info.claimed_at = curr_bn;
+                file_info.expired_on = curr_bn + T::FileDuration::get();
+            }
+
+            // 5. Update files size
+            if file_info.reported_replica_count <= file_info.expected_replica_count {
+                FilesSize::mutate(|fcs| { *fcs = fcs.saturating_add(file_info.file_size as u128); });
+            }
+
+            // 6. Update files
+            <Files<T>>::insert(cid, (file_info, used_info));
+        }
+        return is_counted
+    }
+
+    /// Node who delete the replica
+    /// Accept id(who, anchor), cid and current block number
+    /// Return whether this id is counted to a group/itself's stake limit
+    fn delete_replicas(who: &<T as system::Trait>::AccountId, cid: &MerkleRoot, anchor: &SworkerAnchor, curr_bn: BlockNumber) -> bool {
+        if <Files<T>>::get(cid).is_some() {
+            // 1. Calculate payouts. Try to close file and decrease first party storage(due to no wr)
+            let claimed_bn = Self::calculate_payout(cid, curr_bn);
+            
+            // 2. Delete replica from file_info
+            if let Some((mut file_info, used_info)) = <Files<T>>::get(cid) {
+                // if this anchor didn't report work, we already decrease the `reported_replica_count` in `calculate_payout`
+                if T::SworkerInterface::is_wr_reported(&anchor, claimed_bn) {
+                    // decrease it due to deletion
+                    file_info.reported_replica_count -= 1;
+                    if file_info.reported_replica_count < file_info.expected_replica_count {
+                        FilesSize::mutate(|fcs| { *fcs = fcs.saturating_sub(file_info.file_size as u128); });
+                    }
+                }
+                file_info.replicas.retain(|replica| {
+                    replica.who != *who
+                });
+                <Files<T>>::insert(cid, (file_info, used_info));
+            }
+        }
+
+        // 3. Delete anchor from file_info/file_trash and return whether it is counted
+        Self::delete_used_anchor(cid, anchor)
+    }
+}
+
+/// The module's configuration trait.
+pub trait Trait: system::Trait {
+    /// The market's module id, used for deriving its sovereign account ID.
+    type ModuleId: Get<ModuleId>;
+
+    /// The payment balance.
+    type Currency: ReservableCurrency<Self::AccountId> + TransferrableCurrency<Self::AccountId>;
+
+    /// Converter from Currency<u64> to Balance.
+    type CurrencyToBalance: Convert<BalanceOf<Self>, u64> + Convert<u64, BalanceOf<Self>>;
+
+    /// used to check work report
+    type SworkerInterface: SworkerInterface<Self::AccountId>;
+
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+
+    /// File duration.
+    type FileDuration: Get<BlockNumber>;
+
+    /// File base replica. Use 4 for now
+    type InitialReplica: Get<u32>;
+
+    /// File Base Fee. Use 0.001 CRU for now
+    type FileBaseFee: Get<BalanceOf<Self>>;
+
+    /// File Base Price.
+    type FileInitPrice: Get<BalanceOf<Self>>;
+
+    /// Max limit for the length of sorders in each payment claim.
+    type ClaimLimit: Get<u32>;
+
+    /// Storage reference ratio. total / first class storage
+    type StorageReferenceRatio: Get<u128>;
+
+    /// Storage increase ratio.
+    type StorageIncreaseRatio: Get<Perbill>;
+
+    /// Storage decrease ratio.
+    type StorageDecreaseRatio: Get<Perbill>;
+
+    /// Storage/Staking ratio.
+    type StakingRatio: Get<Perbill>;
+
+    /// UsedTrashMaxSize.
+    type UsedTrashMaxSize: Get<u128>;
+}
+
+// This module's storage items.
+decl_storage! {
+    trait Store for Module<T: Trait> as Market {
+        /// Merchant Ledger
+        pub MerchantLedgers get(fn merchant_ledgers):
+        map hasher(blake2_128_concat) T::AccountId => MerchantLedger<BalanceOf<T>>;
+
+        /// File information iterated by order id
+        pub Files get(fn files):
+        map hasher(twox_64_concat) MerkleRoot => Option<(FileInfo<T::AccountId, BalanceOf<T>>, UsedInfo)>;
+
+        /// File price. It would change according to First Party Storage, Total Storage and Storage Base Ratio.
+        pub FilePrice get(fn file_price): BalanceOf<T> = T::FileInitPrice::get();
+
+        /// First Class Storage
+        pub FilesSize get(fn files_size): u128 = 0;
+
+        /// File trash to store second class storage
+        pub UsedTrashI get(fn used_trash_i):
+        map hasher(twox_64_concat) MerkleRoot => Option<UsedInfo>;
+
+        pub UsedTrashII get(fn used_trash_ii):
+        map hasher(twox_64_concat) MerkleRoot => Option<UsedInfo>;
+
+        pub UsedTrashSizeI get(fn used_trash_size_i): u128 = 0;
+
+        pub UsedTrashSizeII get(fn used_trash_size_ii): u128 = 0;
+
+        pub UsedTrashMappingI get(fn used_trash_mapping_i):
+        map hasher(blake2_128_concat) SworkerAnchor => u64 = 0;
+
+        pub UsedTrashMappingII get(fn used_trash_mapping_ii):
+        map hasher(blake2_128_concat) SworkerAnchor => u64 = 0;
+
+
+    }
+    add_extra_genesis {
+		build(|_config| {
+			// Create Market accounts
+			<Module<T>>::init_pot(<Module<T>>::pledge_pot);
+			<Module<T>>::init_pot(<Module<T>>::storage_pot);
+			<Module<T>>::init_pot(<Module<T>>::staking_pot);
+			<Module<T>>::init_pot(<Module<T>>::reserved_pot);
+		});
+	}
+}
+
+decl_error! {
+    /// Error for the market module.
+    pub enum Error for Module<T: Trait> {
+        /// Don't have enough currency
+        InsufficientCurrency,
+        /// Don't have enough pledge
+        InsufficientPledge,
+        /// Can not bond with value less than minimum balance.
+        InsufficientValue,
+        /// Not Register before
+        NotRegister,
+        /// Register before
+        AlreadyRegistered,
+        /// Reward length is too long
+        RewardLengthTooLong,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+
+        // Initializing events
+        // this is needed only if you are using events in your module
+        fn deposit_event() = default;
+
+        /// The market's module id, used for deriving its sovereign account ID.
+		const ModuleId: ModuleId = T::ModuleId::get();
+
+        /// Register to be a merchant, you should provide your storage layer's address info
+        /// this will require you to pledge first, complexity depends on `Pledges`(P).
+        ///
+        /// # <weight>
+        /// Complexity: O(logP)
+        /// - Read: Pledge
+        /// - Write: Pledge
+        /// # </weight>
+        #[weight = 1000]
+        pub fn register(
+            origin,
+            #[compact] pledge: BalanceOf<T>
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // 1. Reject a pledge which is considered to be _dust_.
+            ensure!(pledge >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
+            // 2. Ensure merchant has enough currency.
+            ensure!(pledge <= T::Currency::transfer_balance(&who), Error::<T>::InsufficientCurrency);
+
+            // 3. Check if merchant has not register before.
+            ensure!(!<MerchantLedgers<T>>::contains_key(&who), Error::<T>::AlreadyRegistered);
+
+            // 4. Transfer from origin to pledge account.
+            T::Currency::transfer(&who, &Self::pledge_pot(), pledge.clone(), AllowDeath).expect("Something wrong during transferring");
+
+            // 5. Prepare new ledger
+            let ledger = MerchantLedger {
+                reward: Zero::zero(),
+                pledge: pledge.clone()
+            };
+
+            // 6. Upsert pledge.
+            <MerchantLedgers<T>>::insert(&who, ledger);
+
+            // 7. Emit success
+            Self::deposit_event(RawEvent::RegisterSuccess(who.clone(), pledge));
+
+            Ok(())
+        }
+
+        /// Pledge extra amount of currency to accept market order.
+        ///
+        /// # <weight>
+        /// Complexity: O(logP)
+        /// - Read: Pledge
+        /// - Write: Pledge
+        /// # </weight>
+        #[weight = 1000]
+        pub fn pledge_extra(origin, #[compact] value: BalanceOf<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // 1. Reject a pledge which is considered to be _dust_.
+            ensure!(value >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
+            // 2. Check if merchant has pledged before
+            ensure!(<MerchantLedgers<T>>::contains_key(&who), Error::<T>::NotRegister);
+
+            // 3. Ensure merchant has enough currency.
+            ensure!(value <= T::Currency::transfer_balance(&who), Error::<T>::InsufficientCurrency);
+
+            // 4. Upgrade pledge.
+            <MerchantLedgers<T>>::mutate(&who, |ledger| { ledger.pledge += value.clone();});
+
+            // 5. Transfer from origin to pledge account.
+            T::Currency::transfer(&who, &Self::pledge_pot(), value.clone(), AllowDeath).expect("Something wrong during transferring");
+
+            // 6. Emit success
+            Self::deposit_event(RawEvent::PledgeExtraSuccess(who.clone(), value));
+
+            Ok(())
+        }
+
+        /// Decrease pledge amount of currency for market order.
+        ///
+        /// # <weight>
+        /// Complexity: O(logP)
+        /// - Read: Pledge
+        /// - Write: Pledge
+        /// # </weight>
+        #[weight = 1000]
+        pub fn cut_pledge(origin, #[compact] value: BalanceOf<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // 1. Reject a pledge which is considered to be _dust_.
+            ensure!(value >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
+            // 2. Check if merchant has pledged before
+            ensure!(<MerchantLedgers<T>>::contains_key(&who), Error::<T>::NotRegister);
+
+            let mut ledger = Self::merchant_ledgers(&who);
+
+            // 3. Ensure value is smaller than unused.
+            ensure!(value <= ledger.pledge - ledger.reward, Error::<T>::InsufficientPledge);
+
+            // 4. Upgrade pledge.
+            ledger.pledge -= value.clone();
+            <MerchantLedgers<T>>::insert(&who, ledger.clone());
+
+            // 5. Transfer from origin to pledge account.
+            T::Currency::transfer(&Self::pledge_pot(), &who, value.clone(), AllowDeath).expect("Something wrong during transferring");
+
+            // 6. Emit success
+            Self::deposit_event(RawEvent::CutPledgeSuccess(who, value));
+
+            Ok(())
+        }
+
+        /// Place a storage order
+        /// TODO: Reconsider this weight
+        #[weight = 1000]
+        pub fn place_storage_order(
+            origin,
+            cid: MerkleRoot,
+            file_size: u64,
+            #[compact] tips: BalanceOf<T>,
+            extend_replica: bool
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: 10% tax
+            // 1. Calculate amount.
+            let amount = T::FileBaseFee::get() + Self::get_file_amount(file_size) + tips;
+
+            // 2. This should not happen at all
+            ensure!(amount >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
+            // 3. Check client can afford the sorder
+            ensure!(T::Currency::transfer_balance(&who) >= amount, Error::<T>::InsufficientCurrency);
+
+            // 4. Split into storage and staking account.
+            let storage_amount = Self::split_into_storage_and_staking_pot(&who, amount.clone());
+
+            let curr_bn = Self::get_current_block_number();
+
+            // 5. calculate payouts. Try to close file and decrease first party storage
+            Self::calculate_payout(&cid, curr_bn);
+
+            // 6. three scenarios: new file, extend time or extend replica
+            Self::upsert_new_file_info(&cid, extend_replica, &storage_amount, &curr_bn, file_size);
+
+            // 7. Update storage price.
+            Self::update_storage_price();
+
+            Self::deposit_event(RawEvent::FileSuccess(who, Self::files(cid).unwrap().0));
+
+            Ok(())
+        }
+
+        /// Calculate the payout
+        /// TODO: Reconsider this weight
+        #[weight = 1000]
+        pub fn calculate_reward(
+            origin,
+            cid: MerkleRoot,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            let curr_bn = Self::get_current_block_number();
+            Self::calculate_payout(&cid, curr_bn);
+            Self::deposit_event(RawEvent::CalculateSuccess(cid));
+            Ok(())
+        }
+
+        // TODO: add claim_reward
+    }
+}
+
+impl<T: Trait> Module<T> {
+    /// The pot of a pledge account
+    pub fn pledge_pot() -> T::AccountId {
+        // "modl" ++ "crmarket" ++ "pled" is 16 bytes
+        T::ModuleId::get().into_sub_account("pled")
+    }
+
+    /// The pot of a storage account
+    pub fn storage_pot() -> T::AccountId {
+        // "modl" ++ "crmarket" ++ "stor" is 16 bytes
+        T::ModuleId::get().into_sub_account("stor")
+    }
+
+    /// The pot of a staking account
+    pub fn staking_pot() -> T::AccountId {
+        // "modl" ++ "crmarket" ++ "stak" is 16 bytes
+        T::ModuleId::get().into_sub_account("stak")
+    }
+
+    /// The pot of a reserved account
+    pub fn reserved_pot() -> T::AccountId {
+        // "modl" ++ "crmarket" ++ "rese" is 16 bytes
+        T::ModuleId::get().into_sub_account("rese")
+    }
+
+    /// Calculate payout from file's replica
+    /// This function will calculate the file's reward, update replicas
+    /// and (maybe) insert file's status(files_size and delete file)
+    /// input:
+    ///     cid: MerkleRoot
+    ///     curr_bn: BlockNumber
+    /// return:
+    ///     claimed_bn: BlockNumber
+    fn calculate_payout(cid: &MerkleRoot, curr_bn: BlockNumber) -> BlockNumber
+    {
+        // 1. File must exist
+        if Self::files(cid).is_none() { return curr_bn; }
+        
+        // 2. File must already started
+        let (mut file_info, used_info) = Self::files(cid).unwrap_or_default();
+        
+        // 3. File already expired
+        if file_info.expired_on <= file_info.claimed_at { return file_info.claimed_at; }
+        
+        // TODO: Restrict the frequency of calculate payout(limit the duration of 2 claiming)
+        // Get the previous first class storage count
+        let prev_first_class_count = file_info.reported_replica_count.min(file_info.expected_replica_count);
+        let claim_block = curr_bn.min(file_info.expired_on);
+        let target_reward_count = file_info.replicas.len().min(file_info.expected_replica_count as usize) as u32;
+        
+        // 4. Calulate payouts, check replicas and update the file_info
+        if target_reward_count > 0 {
+            // 4.1 Get 1 payout amount
+            let one_payout_amount = Perbill::from_rational_approximation(claim_block - file_info.claimed_at,
+                                                                        (file_info.expired_on - file_info.claimed_at) * target_reward_count) * file_info.amount;
+            let mut rewarded_amount = Zero::zero();
+            let mut rewarded_count = 0u32;
+            let mut new_replicas: Vec<Replica<T::AccountId>> = Vec::with_capacity(file_info.replicas.len());
+            let mut invalid_replicas: Vec<Replica<T::AccountId>> = Vec::with_capacity(file_info.replicas.len());
+            
+            // 4.2. Loop replicas
+            for replica in file_info.replicas.iter() {
+                // a. didn't report in prev slot, push back to the end of replica
+                if !T::SworkerInterface::is_wr_reported(&replica.anchor, claim_block) {
+                    let mut invalid_replica = replica.clone();
+                    // update the valid_at to the curr_bn
+                    invalid_replica.valid_at = curr_bn;
+                    // move it to the end of replica
+                    invalid_replicas.push(invalid_replica);
+                    // TODO: kick this anchor out of used info
+                // b. keep the replica's sequence
+                } else {
+                    new_replicas.push(replica.clone());
+                    
+                    // if payouts is full, just continue
+                    if rewarded_count == target_reward_count {
+                        continue;
+                    }
+                    
+                    // if that guy is poor, just pass him ☠️ 
+                    if Self::has_enough_pledge(&replica.who, &one_payout_amount) {
+                        <MerchantLedgers<T>>::mutate(&replica.who, |ledger| {
+                            ledger.reward += one_payout_amount.clone();
+                        });
+                        rewarded_amount += one_payout_amount.clone();
+                        rewarded_count +=1;
+                    }
+                }
+            }
+
+            // 4.3 Update file info
+            file_info.claimed_at = claim_block;
+            file_info.amount -= rewarded_amount;
+            file_info.reported_replica_count = new_replicas.len() as u32;
+            new_replicas.append(&mut invalid_replicas);
+            file_info.replicas = new_replicas;
+        }
+        
+        // 5. Update files
+        <Files<T>>::insert(cid, (file_info.clone(), used_info));
+
+        // 6. Update first class storage size
+        Self::update_files_size(file_info.file_size, prev_first_class_count, file_info.reported_replica_count.min(file_info.expected_replica_count));
+        
+        // 7. Try to close file, judge if it is outdated
+        Self::try_to_close_file(cid, curr_bn);
+
+        // 8. Return the claimed block
+        return claim_block;
+    }
+
+    /// Update the first class storage's size
+    fn update_files_size(file_size: u64, prev_count: u32, curr_count: u32) {
+        FilesSize::mutate(|size| {
+            *size = size.saturating_sub((file_size * (prev_count as u64)) as u128).saturating_add((file_size * (curr_count as u64)) as u128);
+        });
+    }
+
+    /// Close file, maybe move into trash
+    fn try_to_close_file(cid: &MerkleRoot, curr_bn: BlockNumber) {
+        if let Some((file_info, used_info)) = <Files<T>>::get(cid) {
+            // If it's already expired.
+            if file_info.expired_on <= curr_bn {
+                Self::update_files_size(file_info.file_size, file_info.reported_replica_count.min(file_info.expected_replica_count), 0);
+                if file_info.amount != Zero::zero() {
+                    // This should rarely happen.
+                    T::Currency::transfer(&Self::storage_pot(), &Self::reserved_pot(), file_info.amount, AllowDeath).expect("Something wrong during transferring");
+                }
+                Self::move_into_trash(cid, used_info);
+            };
+        }
+    }
+
+    /// Trashbag operations
+    fn move_into_trash(cid: &MerkleRoot, used_info: UsedInfo) {
+        if Self::used_trash_size_i() < T::UsedTrashMaxSize::get() {
+            UsedTrashI::insert(cid, used_info.clone());
+            UsedTrashSizeI::mutate(|value| {*value += 1;});
+            // archive used for each merchant
+            for anchor in used_info.anchors.iter() {
+                UsedTrashMappingI::mutate(&anchor, |value| {
+                    *value += used_info.used_size;
+                })
+            }
+            // trash I is full => dump trash II
+            if Self::used_trash_size_i() == T::UsedTrashMaxSize::get() {
+                Self::dump_used_trash_ii();
+            }
+        } else {
+            UsedTrashII::insert(cid, used_info.clone());
+            UsedTrashSizeII::mutate(|value| {*value += 1;});
+            // archive used for each merchant
+            for anchor in used_info.anchors.iter() {
+                UsedTrashMappingII::mutate(&anchor, |value| {
+                    *value += used_info.used_size;
+                })
+            }
+            // trash II is full => dump trash I
+            if Self::used_trash_size_ii() == T::UsedTrashMaxSize::get() {
+                Self::dump_used_trash_i();
+            }
+        }
+        <Files<T>>::remove(&cid);
+    }
+
+    fn dump_used_trash_i() {
+        for (anchor, used) in UsedTrashMappingI::iter() {
+            T::SworkerInterface::decrease_used(&anchor, used);
+        }
+        remove_storage_prefix(UsedTrashMappingI::module_prefix(), UsedTrashMappingI::storage_prefix(), &[]);
+        remove_storage_prefix(UsedTrashI::module_prefix(), UsedTrashI::storage_prefix(), &[]);
+        UsedTrashSizeI::mutate(|value| {*value = 0;});
+    }
+
+    fn dump_used_trash_ii() {
+        for (anchor, used) in UsedTrashMappingII::iter() {
+            T::SworkerInterface::decrease_used(&anchor, used);
+        }
+        remove_storage_prefix(UsedTrashMappingII::module_prefix(), UsedTrashMappingII::storage_prefix(), &[]);
+        remove_storage_prefix(UsedTrashII::module_prefix(), UsedTrashII::storage_prefix(), &[]);
+        UsedTrashSizeII::mutate(|value| {*value = 0;});
+    }
+
+    fn upsert_new_file_info(cid: &MerkleRoot, extend_replica: bool, amount: &BalanceOf<T>, curr_bn: &BlockNumber, file_size: u64) {
+        // Extend expired_on or expected_replica_count
+        if let Some((mut file_info, used_info)) = Self::files(cid) {
+            let prev_first_class_count = file_info.reported_replica_count.min(file_info.expected_replica_count);
+            if file_info.expired_on > file_info.claimed_at { //if it's already live.
+                file_info.expired_on = curr_bn + T::FileDuration::get();
+            }
+            file_info.amount += amount.clone();
+            if extend_replica {
+                // TODO: use 2 instead of 4
+                file_info.expected_replica_count += T::InitialReplica::get();
+                Self::update_files_size(file_info.file_size, prev_first_class_count, file_info.reported_replica_count.min(file_info.expected_replica_count));
+            }
+            <Files<T>>::insert(cid, (file_info, used_info));
+        } else {
+            // New file
+            let file_info = FileInfo::<T::AccountId, BalanceOf<T>> {
+                file_size,
+                expired_on: curr_bn.clone(), // Not fixed, this will be changed, when first file is reported
+                claimed_at: curr_bn.clone(),
+                amount: amount.clone(),
+                expected_replica_count: T::InitialReplica::get(),
+                reported_replica_count: 0u32,
+                replicas: vec![]
+            };
+            let used_info = UsedInfo {
+                used_size: file_size,
+                anchors: <BTreeSet<SworkerAnchor>>::new()
+            };
+            <Files<T>>::insert(cid, (file_info, used_info));
+        }
+    }
+
+    fn insert_replica(file_info: &mut FileInfo<T::AccountId, BalanceOf<T>>, new_replica: Replica<T::AccountId>) {
+        let mut insert_index: usize = file_info.replicas.len();
+        for (index, replica) in file_info.replicas.iter().enumerate() {
+            if new_replica.valid_at < replica.valid_at {
+                insert_index = index;
+                break;
+            }
+        }
+        file_info.replicas.insert(insert_index, new_replica);
+    }
+
+    fn init_pot(account: fn() -> T::AccountId) {
+        let account_id = account();
+        let min = T::Currency::minimum_balance();
+        if T::Currency::free_balance(&account_id) < min {
+            let _ = T::Currency::make_free_balance_be(
+                &account_id,
+                min,
+            );
+        }
+    }
+
+    fn has_enough_pledge(who: &T::AccountId, value: &BalanceOf<T>) -> bool {
+        let ledger = Self::merchant_ledgers(who);
+        // TODO: 10x pledge value
+        ledger.reward + *value <= ledger.pledge
+    }
+
+    fn update_storage_price() {
+        let total = T::SworkerInterface::get_free_plus_used();
+        let mut file_price = Self::file_price();
+        if let Some(storage_ratio) = total.checked_div(Self::files_size()) {
+            // Too much total => decrease the price
+            if storage_ratio > T::StorageReferenceRatio::get() {
+                let gap = T::StorageDecreaseRatio::get() * file_price;
+                file_price = file_price.saturating_sub(gap);
+            } else {
+                let gap = (T::StorageIncreaseRatio::get() * file_price).max(<T::CurrencyToBalance as Convert<u64, BalanceOf<T>>>::convert(1));
+                file_price = file_price.saturating_add(gap);
+            }
+        } else {
+            let gap = T::StorageDecreaseRatio::get() * file_price;
+            file_price = file_price.saturating_sub(gap);
+        }
+        <FilePrice<T>>::put(file_price);
+    }
+
+    // Calculate file's amount
+    fn get_file_amount(file_size: u64) -> BalanceOf<T> {
+        // Rounded file size from `bytes` to `megabytes`
+        let mut rounded_file_size = file_size / 1_048_576;
+        if file_size % 1_048_576 != 0 {
+            rounded_file_size += 1;
+        }
+        let price = Self::file_price();
+        // Convert file size into `Currency`
+        let amount = price.checked_mul(&<T::CurrencyToBalance as Convert<u64, BalanceOf<T>>>::convert(rounded_file_size));
+        match amount {
+            Some(value) => value,
+            None => Zero::zero(),
+        }
+    }
+
+    fn split_into_storage_and_staking_pot(who: &T::AccountId, value: BalanceOf<T>) -> BalanceOf<T> {
+        let staking_amount = T::StakingRatio::get() * value;
+        let storage_amount = value - staking_amount;
+        T::Currency::transfer(&who, &Self::staking_pot(), staking_amount, AllowDeath).expect("Something wrong during transferring");
+        T::Currency::transfer(&who, &Self::storage_pot(), storage_amount.clone(), AllowDeath).expect("Something wrong during transferring");
+        storage_amount
+    }
+
+    fn get_current_block_number() -> BlockNumber {
+        let current_block_number = <system::Module<T>>::block_number();
+        TryInto::<u32>::try_into(current_block_number).ok().unwrap()
+    }
+
+    fn delete_used_anchor(cid: &MerkleRoot, anchor: &SworkerAnchor) -> bool {
+        let mut is_counted = false;
+        
+        // 1. Delete files anchor
+        <Files<T>>::mutate(cid, |maybe_f| match *maybe_f {
+            Some((_, ref mut used_info)) => {
+                if used_info.anchors.take(anchor).is_some() {
+                    is_counted = true;
+                }
+            },
+            None => {}
+        });
+        
+
+        // 2. Delete trashI's anchor
+        UsedTrashI::mutate(cid, |maybe_used| match *maybe_used {
+            Some(ref mut used_info) => {
+                if used_info.anchors.take(anchor).is_some() {
+                    is_counted = true;
+                    UsedTrashMappingI::mutate(anchor, |value| {
+                        *value -= used_info.used_size;
+                    });
+                }
+            },
+            None => {}
+        });
+
+        // 3. Delete trashII's anchor
+        UsedTrashII::mutate(cid, |maybe_used| match *maybe_used {
+            Some(ref mut used_info) => {
+                if used_info.anchors.take(anchor).is_some() {
+                    is_counted = true;
+                    UsedTrashMappingII::mutate(anchor, |value| {
+                        *value -= used_info.used_size;
+                    });
+                }
+            },
+            None => {}
+        });
+
+        is_counted
+    }
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        AccountId = <T as system::Trait>::AccountId,
+        Balance = BalanceOf<T>
+    {
+        FileSuccess(AccountId, FileInfo<AccountId, Balance>),
+        RegisterSuccess(AccountId, Balance),
+        PledgeExtraSuccess(AccountId, Balance),
+        CutPledgeSuccess(AccountId, Balance),
+        PaysOrderSuccess(AccountId),
+        CalculateSuccess(MerkleRoot),
+    }
+);

--- a/cstrml/market_v2/src/tests.rs
+++ b/cstrml/market_v2/src/tests.rs
@@ -1,0 +1,1511 @@
+use super::*;
+
+use crate::mock::*;
+use frame_support::{
+    assert_noop, assert_ok,
+    dispatch::DispatchError,
+};
+use hex;
+use crate::MerchantLedger;
+
+/// Register & Pledge test cases
+#[test]
+fn register_should_work() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let pledge_pot = Market::pledge_pot();
+        let _ = Balances::make_free_balance_be(&merchant, 200);
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 180));
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 180,
+            reward: 0
+        });
+        assert_eq!(Balances::free_balance(&pledge_pot), 180);
+        assert_ok!(Market::cut_pledge(Origin::signed(merchant.clone()), 20));
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 160,
+            reward: 0
+        });
+        assert_eq!(Balances::free_balance(&pledge_pot), 160);
+        assert_ok!(Market::pledge_extra(Origin::signed(merchant.clone()), 10));
+        assert_eq!(Market::merchant_ledgers(merchant), MerchantLedger {
+            pledge: 170,
+            reward: 0
+        });
+        assert_eq!(Balances::free_balance(&pledge_pot), 170);
+    });
+}
+
+#[test]
+fn register_should_fail_due_to_insufficient_currency() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&merchant, 100);
+        assert_noop!(
+            Market::register(
+                Origin::signed(merchant),
+                200
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 0,
+                message: Some("InsufficientCurrency")
+            }
+        );
+    });
+}
+
+#[test]
+fn register_should_fail_due_to_double_register() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&merchant, 200);
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 70));
+        assert_noop!(
+            Market::register(
+                Origin::signed(merchant),
+                70
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 4,
+                message: Some("AlreadyRegistered")
+            }
+        );
+    });
+}
+
+#[test]
+fn pledge_extra_should_fail_due_to_merchant_not_register() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&merchant, 200);
+        assert_noop!(
+            Market::pledge_extra(
+                Origin::signed(merchant),
+                200
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 3,
+                message: Some("NotRegister")
+            }
+        );
+    });
+}
+
+#[test]
+fn cut_pledge_should_fail_due_to_reward() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&merchant, 200);
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 180));
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 180,
+            reward: 0
+        });
+
+        <self::MerchantLedgers<Test>>::insert(&merchant, MerchantLedger {
+            pledge: 180,
+            reward: 120
+        });
+        assert_ok!(Market::cut_pledge(Origin::signed(merchant.clone()), 20));
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 160,
+            reward: 120
+        });
+        assert_noop!(
+            Market::cut_pledge(
+                Origin::signed(merchant),
+                50
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 1,
+                message: Some("InsufficientPledge")
+            }
+        );
+    });
+}
+
+/// Place storage order test cases
+#[test]
+fn place_storage_order_should_work() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+        hex::decode("4e2883ddcbc77cf19979770d756fd332d0c8f815f9de646636169e460e6af6ff").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 200);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 60));
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+        assert_eq!(Balances::free_balance(staking_pot), 1600);
+        assert_eq!(Balances::free_balance(storage_pot), 400);
+    });
+}
+
+#[test]
+// For extends:
+// 1. Add amount
+// 2. Extend duration
+// 3. Extend replicas
+fn place_storage_order_should_work_for_extend_scenarios() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 6000));
+
+        // 1. New storage order
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+        assert_eq!(Balances::free_balance(&staking_pot), 1600);
+        assert_eq!(Balances::free_balance(&storage_pot), 400);
+
+        run_to_block(250);
+        
+        // 2. Add amount for sOrder not begin should work
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 800, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+        assert_eq!(Balances::free_balance(&staking_pot), 3200);
+        assert_eq!(Balances::free_balance(&storage_pot), 800);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        // Report this cid's works
+        register(&legal_pk, LegalCode::get());
+        run_to_block(400);
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1400,
+                claimed_at: 400,
+                amount: 800, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        // Calculate mannual claim reward should work
+        run_to_block(500);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 0, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1400,
+                claimed_at: 500,
+                amount: 720,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        // 3. Extend duration should work
+        run_to_block(600);
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1600,
+                claimed_at: 600,
+                amount: 1040,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        // 4. Extend replicas should work
+        run_to_block(800);
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 200, true
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1800,
+                claimed_at: 800,
+                amount: 1272,
+                expected_replica_count: 8,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+    });
+}
+
+
+/// Payouts test cases
+#[test]
+// Payout should be triggered by:
+// 1. Delete file(covered by swork module)
+// 2. Claim reward
+// 3. Place started storage order(covered by `place_storage_order_should_work_for_extend_scenarios`)
+fn calculate_payout_should_work() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+ 
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 6000));
+
+        // 1. Place an order 1st
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        assert_eq!(Balances::free_balance(staking_pot), 1600);
+        assert_eq!(Balances::free_balance(storage_pot), 400);
+
+        run_to_block(303);
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        register(&legal_pk, LegalCode::get());
+
+        // 2. Report this file's work, let file begin
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        // 3. Go along with some time, and get reward
+        run_to_block(606);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 300, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 606,
+                amount: 279, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 121
+        })
+    });
+}
+
+#[test]
+fn calculate_payout_should_fail_due_to_insufficient_pledge() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 60));
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        assert_eq!(Balances::free_balance(staking_pot), 1600);
+        assert_eq!(Balances::free_balance(storage_pot), 400);
+
+        run_to_block(303);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        register(&legal_pk, LegalCode::get());
+
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        run_to_block(603);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 300, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 603,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        // pledge is 60 < 121 reward
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 60,
+            reward: 0
+        });
+
+        run_to_block(903);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 600, true);
+        assert_ok!(Market::pledge_extra(Origin::signed(merchant.clone()), 6000));
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 903,
+                amount: 229, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6060,
+            reward: 171
+        })
+    });
+}
+
+#[test]
+fn calculate_payout_should_move_file_to_trash_due_to_expired() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 6000));
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        assert_eq!(Balances::free_balance(staking_pot), 1600);
+        assert_eq!(Balances::free_balance(storage_pot), 400);
+
+        run_to_block(303);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        register(&legal_pk, LegalCode::get());
+
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        run_to_block(1506);
+        // expired_on is 1303. So to check 900
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 900, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid), None);
+
+        assert_eq!(Market::used_trash_i(&cid).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 400
+        })
+    });
+}
+
+#[test]
+fn calculate_payout_should_work_in_complex_timeline() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let charlie = Sr25519Keyring::Charlie.to_account_id();
+        let dave = Sr25519Keyring::Dave.to_account_id();
+        let eve = Sr25519Keyring::Eve.to_account_id();
+
+        let staking_pot = Market::staking_pot();
+        let storage_pot = Market::storage_pot();
+        let reserved_pot = Market::reserved_pot();
+        assert_eq!(Balances::free_balance(&staking_pot), 0);
+        assert_eq!(Balances::free_balance(&reserved_pot), 0);
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let merchants = vec![merchant.clone(), charlie.clone(), dave.clone(), eve.clone()];
+        for who in merchants.iter() {
+            let _ = Balances::make_free_balance_be(&who, 20000);
+            assert_ok!(Market::register(Origin::signed(who.clone()), 6000));
+        }
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        assert_eq!(Balances::free_balance(staking_pot), 1600);
+        assert_eq!(Balances::free_balance(storage_pot), 400);
+
+        run_to_block(303);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        register(&legal_pk, LegalCode::get());
+
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files_size(), file_size as u128);
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        run_to_block(503);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 0, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 503,
+                amount: 320,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: merchant.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 80
+        });
+
+        add_who_into_replica(&cid, charlie.clone(), legal_pk.clone(), None);
+
+        run_to_block(603);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 300, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 603,
+                amount: 280,
+                expected_replica_count: 4,
+                reported_replica_count: 2,
+                replicas: vec![
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 100
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 20
+        });
+
+        assert_eq!(Market::files_size(), (file_size * 2) as u128);
+
+        add_who_into_replica(&cid, dave.clone(), hex::decode("11").unwrap(), None);
+        run_to_block(703);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 703,
+                amount: 254,
+                expected_replica_count: 4,
+                reported_replica_count: 2,
+                replicas: vec![
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: dave.clone(),
+                        valid_at: 703, // did't report. change it to curr bn
+                        anchor: hex::decode("11").unwrap()
+                    }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone(), hex::decode("11").unwrap()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 113
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 33
+        });
+
+        assert_eq!(Market::files_size(), (file_size * 2) as u128);
+
+        run_to_block(903);
+        <swork::ReportedInSlot>::insert(hex::decode("11").unwrap(), 600, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 903,
+                amount: 226,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![
+                    Replica {
+                        who: dave.clone(),
+                        valid_at: 703,
+                        anchor: hex::decode("11").unwrap()
+                    },
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 903, // did't report. change it to curr bn
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 903, // did't report. change it to curr bn
+                        anchor: legal_pk.clone()
+                    }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone(), hex::decode("11").unwrap()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 113
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 33
+        });
+        assert_eq!(Market::merchant_ledgers(&dave), MerchantLedger {
+            pledge: 6000,
+            reward: 28
+        });
+
+        assert_eq!(Market::files_size(), file_size as u128);
+
+        run_to_block(1203);
+        <swork::ReportedInSlot>::insert(hex::decode("11").unwrap(), 900, true);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 900, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 1203,
+                amount: 58,
+                expected_replica_count: 4,
+                reported_replica_count: 3,
+                replicas: vec![
+                    Replica {
+                        who: dave.clone(),
+                        valid_at: 703,
+                        anchor: hex::decode("11").unwrap()
+                    },
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 903,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 903,
+                        anchor: legal_pk.clone()
+                    }]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone(), hex::decode("11").unwrap()].into_iter())
+            })
+        );
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 169
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 89
+        });
+        assert_eq!(Market::merchant_ledgers(&dave), MerchantLedger {
+            pledge: 6000,
+            reward: 84
+        });
+        assert_eq!(Market::files_size(), (file_size * 3) as u128);
+
+        run_to_block(1803);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        let mut anchors = <BTreeSet<SworkerAnchor>>::new();
+        anchors.insert(legal_pk.clone());
+        anchors.insert(hex::decode("11").unwrap());
+        assert_eq!(Market::used_trash_i(&cid).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors
+        });
+
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 188
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 108
+        });
+        assert_eq!(Market::merchant_ledgers(&dave), MerchantLedger {
+            pledge: 6000,
+            reward: 103
+        });
+        assert_eq!(Market::files_size(), 0);
+        assert_eq!(Balances::free_balance(&reserved_pot), 1);
+    });
+}
+
+#[test]
+fn calculate_payout_should_fail_due_to_not_live() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        // pledge is 60 < 121 reward
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 6000));
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        run_to_block(303);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        register(&legal_pk, LegalCode::get());
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        run_to_block(1506);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+    });
+}
+
+#[test]
+fn calculate_payout_should_work_for_more_replicas() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let charlie = Sr25519Keyring::Charlie.to_account_id();
+        let dave = Sr25519Keyring::Dave.to_account_id();
+        let eve = Sr25519Keyring::Eve.to_account_id();
+        let ferdie = Sr25519Keyring::Ferdie.to_account_id();
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let merchants = vec![merchant.clone(), charlie.clone(), dave.clone(), eve.clone(), ferdie.clone()];
+        for who in merchants.iter() {
+            let _ = Balances::make_free_balance_be(&who, 20000);
+            assert_ok!(Market::register(Origin::signed(who.clone()), 6000));
+        }
+
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source), cid.clone(),
+            file_size, 0, false
+        ));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+        );
+
+        run_to_block(303);
+
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+
+        add_who_into_replica(&cid, ferdie.clone(), legal_pk.clone(), Some(303u32));
+        assert_eq!(Market::files_size(), file_size as u128);
+        add_who_into_replica(&cid, charlie.clone(), legal_pk.clone(), Some(403u32));
+        assert_eq!(Market::files_size(), (file_size * 2) as u128);
+        add_who_into_replica(&cid, dave.clone(), legal_pk.clone(), Some(503u32));
+        assert_eq!(Market::files_size(), (file_size * 3) as u128);
+
+        register(&legal_pk, LegalCode::get());
+
+        assert_ok!(Swork::report_works(
+                Origin::signed(merchant.clone()),
+                legal_wr_info.curr_pk,
+                legal_wr_info.prev_pk,
+                legal_wr_info.block_number,
+                legal_wr_info.block_hash,
+                legal_wr_info.free,
+                legal_wr_info.used,
+                legal_wr_info.added_files,
+                legal_wr_info.deleted_files,
+                legal_wr_info.srd_root,
+                legal_wr_info.files_root,
+                legal_wr_info.sig
+            ));
+
+        assert_eq!(Market::files_size(), (file_size * 4) as u128);
+
+        add_who_into_replica(&cid, eve.clone(), legal_pk.clone(), Some(503u32));
+
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 5,
+                replicas: vec![
+                    Replica {
+                        who: ferdie.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 403,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: dave.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: eve.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    }
+                ]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+        run_to_block(503);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 0, true);
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid.clone()));
+        assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 1303,
+                claimed_at: 503,
+                amount: 320,
+                expected_replica_count: 4,
+                reported_replica_count: 5,
+                replicas: vec![
+                    Replica {
+                        who: ferdie.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: merchant.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: charlie.clone(),
+                        valid_at: 403,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: dave.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    },
+                    Replica {
+                        who: eve.clone(),
+                        valid_at: 503,
+                        anchor: legal_pk.clone()
+                    }
+                ]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+            })
+        );
+
+        assert_eq!(Market::merchant_ledgers(&ferdie), MerchantLedger {
+            pledge: 6000,
+            reward: 20
+        });
+        assert_eq!(Market::merchant_ledgers(&merchant), MerchantLedger {
+            pledge: 6000,
+            reward: 20
+        });
+        assert_eq!(Market::merchant_ledgers(&charlie), MerchantLedger {
+            pledge: 6000,
+            reward: 20
+        });
+        assert_eq!(Market::merchant_ledgers(&dave), MerchantLedger {
+            pledge: 6000,
+            reward: 20
+        });
+        assert_eq!(Market::merchant_ledgers(&eve), MerchantLedger {
+            pledge: 6000,
+            reward: 0
+        });
+    });
+}
+
+
+/// Trash test case
+#[test]
+fn clear_trash_should_work() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        run_to_block(50);
+
+        let source = Sr25519Keyring::Alice.to_account_id();
+        let cid1 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap();
+        let cid2 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b661").unwrap();
+        let cid3 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b662").unwrap();
+        let cid4 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b663").unwrap();
+        let cid5 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b664").unwrap();
+        let cid6 =
+            hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b665").unwrap();
+        let file_lists = vec![cid1.clone(), cid2.clone(), cid3.clone(), cid4.clone(), cid5.clone(), cid6.clone()];
+        let file_size = 100; // should less than merchant
+        let merchant = Sr25519Keyring::Bob.to_account_id();
+        let _ = Balances::make_free_balance_be(&source, 20000);
+        let _ = Balances::make_free_balance_be(&merchant, 20000);
+
+        assert_ok!(Market::register(Origin::signed(merchant.clone()), 6000));
+
+        for cid in file_lists.clone().iter() {
+            assert_ok!(Market::place_storage_order(
+                Origin::signed(source.clone()), cid.clone(),
+                file_size, 0, false
+            ));
+            assert_eq!(Market::files(&cid).unwrap_or_default(), (
+            FileInfo {
+                file_size,
+                expired_on: 50,
+                claimed_at: 50,
+                amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                expected_replica_count: 4,
+                reported_replica_count: 0,
+                replicas: vec![]
+            },
+            UsedInfo {
+                used_size: file_size,
+                anchors: BTreeSet::from_iter(vec![].into_iter())
+            })
+            );
+        }
+
+        run_to_block(303);
+        let legal_wr_info = legal_work_report_with_added_files();
+        let legal_pk = legal_wr_info.curr_pk.clone();
+        register(&legal_pk, LegalCode::get());
+        for cid in file_lists.clone().iter() {
+            add_who_into_replica(&cid, merchant.clone(), legal_pk.clone(), None);
+        }
+
+        for cid in file_lists.clone().iter() {
+            assert_eq!(Market::files(&cid).unwrap_or_default(), (
+                FileInfo {
+                    file_size,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 400, // ( 1000 + 1000 * 1 + 0 ) * 0.2
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![Replica {
+                        who: merchant.clone(),
+                        valid_at: 303,
+                        anchor: legal_pk.clone()
+                    }]
+                },
+                UsedInfo {
+                    used_size: file_size,
+                    anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+                })
+            );
+        }
+
+        run_to_block(1500);
+        <swork::ReportedInSlot>::insert(legal_pk.clone(), 900, true);
+        // close files one by one
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid1.clone()));
+        assert_eq!(Market::used_trash_i(&cid1).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid2.clone()));
+        assert_eq!(Market::used_trash_i(&cid2).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid3.clone()));
+        assert_eq!(Market::used_trash_ii(&cid3).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid4.clone()));
+        assert_eq!(Market::used_trash_ii(&cid4).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+        assert_eq!(Market::used_trash_i(&cid1), None);
+        assert_eq!(Market::used_trash_i(&cid2), None);
+
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid5.clone()));
+        assert_eq!(Market::used_trash_i(&cid5).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_ok!(Market::calculate_reward(Origin::signed(merchant.clone()), cid6.clone()));
+        assert_eq!(Market::used_trash_i(&cid6).unwrap_or_default(), UsedInfo {
+            used_size: file_size,
+            anchors: BTreeSet::from_iter(vec![legal_pk.clone()].into_iter())
+        });
+
+        assert_eq!(Market::used_trash_ii(&cid3), None);
+        assert_eq!(Market::used_trash_ii(&cid4), None);
+    });
+}
+
+/// Update file price test case
+#[test]
+fn update_price_should_work() {
+    new_test_ext().execute_with(|| {
+        // generate 50 blocks first
+        // 0 / 0 => None => decrease
+        Market::update_storage_price();
+        assert_eq!(Market::file_price(), 990);
+
+        run_to_block(50);
+        // first class storage is 0
+        <swork::Free>::put(10000);
+        <swork::Used>::put(10000);
+        assert_eq!(Swork::get_free_plus_used(), 20000);
+        Market::update_storage_price();
+        assert_eq!(Market::file_price(), 980);
+
+        // first class storage is 11000 => increase 1%
+        FilesSize::put(11000);
+        Market::update_storage_price();
+        assert_eq!(Market::file_price(), 990);
+
+        // price is 40 and cannot decrease
+        <FilePrice<Test>>::put(40);
+        FilesSize::put(10);
+        Market::update_storage_price();
+        assert_eq!(Market::file_price(), 40);
+
+        // price is 40 and will increase by 1
+        FilesSize::put(20000);
+        Market::update_storage_price();
+        assert_eq!(Market::file_price(), 41);
+    });
+}
+

--- a/cstrml/swork/Cargo.toml
+++ b/cstrml/swork/Cargo.toml
@@ -28,6 +28,7 @@ frame-benchmarking = { version = '2.0.0', default-features = false, optional = t
 
 # crust runtime modules
 market = { version = "0.10.0", package = 'cstrml-market', path = '../market', default-features = false }
+market_v2 = { version = "0.10.0", package = 'cstrml-market-v2', path = '../market_v2', default-features = false }
 primitives = { version = "0.10.0", package = 'cst-primitives', path = '../../primitives', default-features = false }
 webpki = { version = "0.21.0", package = 'webpki', path = '../../utils/webpki', default-features = false }
 serde_json = { version = "1.0.59", package = "serde_json_no_std", path = '../../utils/serde_json_no_std', default-features = false, features = ["alloc"] }
@@ -51,6 +52,7 @@ std = [
     'frame-system/std',
     'sp-runtime-interface/std',
     'market/std',
+    'market_v2/std',
     'primitives/std',
     'webpki/std'
 ]

--- a/cstrml/swork/Cargo.toml
+++ b/cstrml/swork/Cargo.toml
@@ -28,7 +28,6 @@ frame-benchmarking = { version = '2.0.0', default-features = false, optional = t
 
 # crust runtime modules
 market = { version = "0.10.0", package = 'cstrml-market', path = '../market', default-features = false }
-market_v2 = { version = "0.10.0", package = 'cstrml-market-v2', path = '../market_v2', default-features = false }
 primitives = { version = "0.10.0", package = 'cst-primitives', path = '../../primitives', default-features = false }
 webpki = { version = "0.21.0", package = 'webpki', path = '../../utils/webpki', default-features = false }
 serde_json = { version = "1.0.59", package = "serde_json_no_std", path = '../../utils/serde_json_no_std', default-features = false, features = ["alloc"] }
@@ -36,6 +35,7 @@ serde_json = { version = "1.0.59", package = "serde_json_no_std", path = '../../
 [dev-dependencies]
 keyring = { package = "sp-keyring", version = '2.0.0' }
 balances = { version = "0.10.0", package = 'cstrml-balances', path = '../balances' }
+market_v2 = { version = "0.10.0", package = 'cstrml-market-v2', path = '../market_v2' }
 frame-benchmarking = { version = '2.0.0' }
 hex = '0.4.2'
 
@@ -52,7 +52,6 @@ std = [
     'frame-system/std',
     'sp-runtime-interface/std',
     'market/std',
-    'market_v2/std',
     'primitives/std',
     'webpki/std'
 ]

--- a/cstrml/swork/src/benchmarking.rs
+++ b/cstrml/swork/src/benchmarking.rs
@@ -29,58 +29,44 @@ benchmarks! {
         let sig: Vec<u8> = vec![153,15,132,203,16,61,189,174,53,69,117,139,125,120,121,86,243,25,28,226,237,230,56,194,238,228,22,182,116,166,245,27,86,43,129,7,122,13,3,143,247,159,97,239,88,200,8,51,238,45,204,71,25,38,46,164,18,85,82,175,13,48,15,190];
     }: _(RawOrigin::Signed(caller.clone()), ias_sig.to_vec(), ias_cert.to_vec(), caller.clone(), isv_body.to_vec(), sig)
 
-    report_works {
-        let code: Vec<u8> = vec![226,86,171,76,181,233,19,107,193,193,17,80,136,252,64,202,31,65,130,84,94,167,87,105,87,140,32,216,67,2,140,213];    
-        let expire_block: T::BlockNumber = BLOCK_NUMBER.into();
-        Swork::<T>::upgrade(RawOrigin::Root.into(), code.clone(), expire_block).expect("failed to insert code");
-        let user: Vec<u8> = vec![212,53,147,199,21,253,211,28,97,20,26,189,4,169,159,214,130,44,133,88,133,76,205,227,154,86,132,231,165,109,162,125];
-        let caller = T::AccountId::decode(&mut &user[..]).unwrap_or_default();
-        let pub_key = vec![124,22,192,160,215,161,204,246,84,170,41,37,254,86,87,88,35,151,42,218,160,18,95,251,132,61,154,28,174,14,31,46,164,243,216,32,255,89,213,99,31,248,115,105,57,54,235,198,185,29,10,242,43,130,18,153,1,157,186,207,64,245,121,29];
-        let prev_key: Vec<u8> = vec![];
-        let block_number = 300;
-        // let block_hash = vec![5,64,75,105,11,12,120,91,241,128,178,221,130,164,49,216,141,41,186,243,19,70,197,61,189,169,94,131,227,76,138,117];
-        let block_hash = vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
-        let free = 4294967296;
-        let used = 402868224;
-        let added_files: Vec<(Vec<u8>, u64)> = vec![
-            (vec![91,183,6,50,10,252,99,59,251,132,49,8,228,146,25,43,23,210,182,185,217,238,11,121,94,233,84,23,254,8,182,96],134289408),
-            (vec![136,205,179,21,200,195,126,45,192,15,162,168,199,254,81,184,20,155,54,61,41,244,4,68,25,130,249,109,43,186,230,95],268578816)
-        ];
-        let deleted_files: Vec<(Vec<u8>, u64)> = vec![];
-        let sig: Vec<u8> = vec![179,247,136,99,236,151,41,85,217,202,34,212,68,165,71,80,133,164,247,151,90,115,138,186,30,174,29,152,221,113,143,198,145,167,122,53,183,100,161,72,163,168,97,164,162,239,50,121,243,213,226,95,96,124,115,202,133,234,134,225,23,107,166,98];
-        let files_root: Vec<u8> = vec![17];
-        let srd_root: Vec<u8> = vec![0];
-        Swork::<T>::maybe_upsert_id(&caller, &pub_key, &code);
-        system::Module::<T>::set_block_number(303.into());
-        let fake_bh:T::Hash = T::Hash::decode(&mut &block_hash[..]).unwrap_or_default();
-        let t_block_number:T::BlockNumber = 300.into();
-        <system::BlockHash<T>>::insert(t_block_number, fake_bh);
-    }: _(RawOrigin::Signed(caller.clone()),
-        pub_key,
-        prev_key,
-        block_number,
-        block_hash,
-        free,
-        used,
-        added_files,
-        deleted_files,
-        srd_root,
-        files_root,
-        sig)
-
-    chill_pk {
-        let code: Vec<u8> = vec![120,27,83,125,61,206,243,157,236,123,139,206,111,223,205,3,45,141,132,102,64,233,181,89,139,74,159,98,113,136,169,8];
-        let expire_block: T::BlockNumber = BLOCK_NUMBER.into();
-        Swork::<T>::upgrade(RawOrigin::Root.into(), code, expire_block).expect("failed to insert code");
-        let user: Vec<u8> = vec![166,239,163,116,112,15,134,64,183,119,188,146,199,125,52,68,124,85,136,215,235,124,78,201,132,50,60,125,176,152,48,9];
-        let caller = T::AccountId::decode(&mut &user[..]).unwrap_or_default();
-        let ias_sig = "VWfhb8pfVTHFcwIfFI9fLQPPvScGKwWOtkhYzlIMP5MT/u81VMAJed37p87YyMNwpqopaTP6/QVLkrZFw6fRgONMY+kRyzzkUDB3gRhRh71ZqZe0R+XHsGi6QH0YnMiXtCnD9oP3vSKx8UqhMKRpn4eCUU2jKLkoUOT8fiwozOnrIfYH5aVLcF65Laomj0trgoFbJlm/Yag7HOA3mQMRgCoBzP+xeKZBCWr/Zh6814mnwb8X79KVpM7suiy+g0KuZQpjH9qE32XsBL7lNizqVji9XiAJwN6pbhDmQaRbB8y46mJ1HkII+SFHCyBWAtdiqH9cTsmbsTjAS/TjoXcphQ==".as_bytes();
-        let ias_cert = "MIIEoTCCAwmgAwIBAgIJANEHdl0yo7CWMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNVBAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwHhcNMTYxMTIyMDkzNjU4WhcNMjYxMTIwMDkzNjU4WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExFDASBgNVBAcMC1NhbnRhIENsYXJhMRowGAYDVQQKDBFJbnRlbCBDb3Jwb3JhdGlvbjEtMCsGA1UEAwwkSW50ZWwgU0dYIEF0dGVzdGF0aW9uIFJlcG9ydCBTaWduaW5nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqXot4OZuphR8nudFrAFiaGxxkgma/Es/BA+tbeCTUR106AL1ENcWA4FX3K+E9BBL0/7X5rj5nIgX/R/1ubhkKWw9gfqPG3KeAtIdcv/uTO1yXv50vqaPvE1CRChvzdS/ZEBqQ5oVvLTPZ3VEicQjlytKgN9cLnxbwtuvLUK7eyRPfJW/ksddOzP8VBBniolYnRCD2jrMRZ8nBM2ZWYwnXnwYeOAHV+W9tOhAImwRwKF/95yAsVwd21ryHMJBcGH70qLagZ7Ttyt++qO/6+KAXJuKwZqjRlEtSEz8gZQeFfVYgcwSfo96oSMAzVr7V0L6HSDLRnpb6xxmbPdqNol4tQIDAQABo4GkMIGhMB8GA1UdIwQYMBaAFHhDe3amfrzQr35CN+s1fDuHAVE8MA4GA1UdDwEB/wQEAwIGwDAMBgNVHRMBAf8EAjAAMGAGA1UdHwRZMFcwVaBToFGGT2h0dHA6Ly90cnVzdGVkc2VydmljZXMuaW50ZWwuY29tL2NvbnRlbnQvQ1JML1NHWC9BdHRlc3RhdGlvblJlcG9ydFNpZ25pbmdDQS5jcmwwDQYJKoZIhvcNAQELBQADggGBAGcIthtcK9IVRz4rRq+ZKE+7k50/OxUsmW8aavOzKb0iCx07YQ9rzi5nU73tME2yGRLzhSViFs/LpFa9lpQL6JL1aQwmDR74TxYGBAIi5f4I5TJoCCEqRHz91kpG6Uvyn2tLmnIdJbPE4vYvWLrtXXfFBSSPD4Afn7+3/XUggAlc7oCTizOfbbtOFlYA4g5KcYgS1J2ZAeMQqbUdZseZCcaZZZn65tdqee8UXZlDvx0+NdO0LR+5pFy+juM0wWbu59MvzcmTXbjsi7HY6zd53Yq5K244fwFHRQ8eOB0IWB+4PfM7FeAApZvlfqlKOlLcZL2uyVmzRkyR5yW72uo9mehX44CiPJ2fse9Y6eQtcfEhMPkmHXI01sN+KwPbpA39+xOsStjhP9N1Y1a2tQAVo+yVgLgV2Hws73Fc0o3wC78qPEA+v2aRs/Be3ZFDgDyghc/1fgU+7C+P6kbqd4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==".as_bytes();
-        let isv_body = "{\"id\":\"224446224973977124963950294138353548427\",\"timestamp\":\"2020-10-27T07:26:53.412131\",\"version\":3,\"epidPseudonym\":\"4tcrS6EX9pIyhLyxtgpQJuMO1VdAkRDtha/N+u/rRkTsb11AhkuTHsY6UXRPLRJavxG3nsByBdTfyDuBDQTEjMYV6NBXjn3P4UyvG1Ae2+I4lE1n+oiKgLA8CR8pc2nSnSY1Wz1Pw/2l9Q5Er6hM6FdeECgMIVTZzjScYSma6rE=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000F00000F0F02040101070000000000000000000B00000B00000002000000000000142ADC0536C0F778E6339B78B7495BDAB064CBC27DA1049CE6739151D0F781995C52276F171A92BE72FDDC4A5602B353742E9DF16256EADC00D3577943656DFEEE1B\",\"isvEnclaveQuoteBody\":\"AgABACoUAAAKAAkAAAAAAP7yPH5zo3mCPOcf8onPvAcAAAAAAAAAAAAAAAAAAAAACBD///8CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAHgbU309zvOd7HuLzm/fzQMtjYRmQOm1WYtKn2JxiKkIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADLinsnSTdJyTnaS7pyZvFHa7lg50iRgXVEUDISYg3OPJThwmxiLMuahAQViB3u9UErVI8ip9XlwF+0Es/cjlRk\"}".as_bytes();
-        let sig: Vec<u8> = vec![153,15,132,203,16,61,189,174,53,69,117,139,125,120,121,86,243,25,28,226,237,230,56,194,238,228,22,182,116,166,245,27,86,43,129,7,122,13,3,143,247,159,97,239,88,200,8,51,238,45,204,71,25,38,46,164,18,85,82,175,13,48,15,190];
-        Swork::<T>::register(RawOrigin::Signed(caller.clone()).into(), ias_sig.to_vec(), ias_cert.to_vec(), caller.clone(), isv_body.to_vec(), sig).expect("failed to register identity");
-        let pk: Vec<u8> = vec![203,138,123,39,73,55,73,201,57,218,75,186,114,102,241,71,107,185,96,231,72,145,129,117,68,80,50,18,98,13,206,60,148,225,194,108,98,44,203,154,132,4,21,136,29,238,245,65,43,84,143,34,167,213,229,192,95,180,18,207,220,142,84,100];
-    }: _(RawOrigin::Signed(caller.clone()), pk)
+    // report_works {
+    //     let code: Vec<u8> = vec![226,86,171,76,181,233,19,107,193,193,17,80,136,252,64,202,31,65,130,84,94,167,87,105,87,140,32,216,67,2,140,213];
+    //     let expire_block: T::BlockNumber = BLOCK_NUMBER.into();
+    //     Swork::<T>::upgrade(RawOrigin::Root.into(), code.clone(), expire_block).expect("failed to insert code");
+    //     let user: Vec<u8> = vec![212,53,147,199,21,253,211,28,97,20,26,189,4,169,159,214,130,44,133,88,133,76,205,227,154,86,132,231,165,109,162,125];
+    //     let caller = T::AccountId::decode(&mut &user[..]).unwrap_or_default();
+    //     let pub_key = vec![124,22,192,160,215,161,204,246,84,170,41,37,254,86,87,88,35,151,42,218,160,18,95,251,132,61,154,28,174,14,31,46,164,243,216,32,255,89,213,99,31,248,115,105,57,54,235,198,185,29,10,242,43,130,18,153,1,157,186,207,64,245,121,29];
+    //     let prev_key: Vec<u8> = vec![];
+    //     let block_number = 300;
+    //     // let block_hash = vec![5,64,75,105,11,12,120,91,241,128,178,221,130,164,49,216,141,41,186,243,19,70,197,61,189,169,94,131,227,76,138,117];
+    //     let block_hash = vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
+    //     let free = 4294967296;
+    //     let used = 402868224;
+    //     let added_files: Vec<(Vec<u8>, u64)> = vec![
+    //         (vec![91,183,6,50,10,252,99,59,251,132,49,8,228,146,25,43,23,210,182,185,217,238,11,121,94,233,84,23,254,8,182,96],134289408),
+    //         (vec![136,205,179,21,200,195,126,45,192,15,162,168,199,254,81,184,20,155,54,61,41,244,4,68,25,130,249,109,43,186,230,95],268578816)
+    //     ];
+    //     let deleted_files: Vec<(Vec<u8>, u64)> = vec![];
+    //     let sig: Vec<u8> = vec![179,247,136,99,236,151,41,85,217,202,34,212,68,165,71,80,133,164,247,151,90,115,138,186,30,174,29,152,221,113,143,198,145,167,122,53,183,100,161,72,163,168,97,164,162,239,50,121,243,213,226,95,96,124,115,202,133,234,134,225,23,107,166,98];
+    //     let files_root: Vec<u8> = vec![17];
+    //     let srd_root: Vec<u8> = vec![0];
+    //     Swork::<T>::maybe_upsert_id(&caller, &pub_key, &code);
+    //     system::Module::<T>::set_block_number(303.into());
+    //     let fake_bh:T::Hash = T::Hash::decode(&mut &block_hash[..]).unwrap_or_default();
+    //     let t_block_number:T::BlockNumber = 300.into();
+    //     <system::BlockHash<T>>::insert(t_block_number, fake_bh);
+    // }: _(RawOrigin::Signed(caller.clone()),
+    //     pub_key,
+    //     prev_key,
+    //     block_number,
+    //     block_hash,
+    //     free,
+    //     used,
+    //     added_files,
+    //     deleted_files,
+    //     srd_root,
+    //     files_root,
+    //     sig)
 }
 
 #[cfg(test)]
@@ -107,21 +93,12 @@ mod tests {
         });
     }
 
-    #[test]
-    fn report_works() {
-        ExtBuilder::default()
-            .build()
-            .execute_with(|| {
-                assert_ok!(test_benchmark_report_works::<Test>());
-            });
-    }
-
-    #[test]
-    fn chill_pk() {
-        ExtBuilder::default()
-            .build()
-            .execute_with(|| {
-                assert_ok!(test_benchmark_chill_pk::<Test>());
-            });
-    }
+    // #[test]
+    // fn report_works() {
+    //     ExtBuilder::default()
+    //         .build()
+    //         .execute_with(|| {
+    //             assert_ok!(test_benchmark_report_works::<Test>());
+    //         });
+    // }
 }

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -83,8 +83,8 @@ pub struct WorkReport {
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PKInfo {
-    code: SworkerCode,
-    anchor: Option<SworkerAnchor> // is bonded to an account or not in report work
+    pub code: SworkerCode,
+    pub anchor: Option<SworkerAnchor> // is bonded to an account or not in report work
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
@@ -92,8 +92,8 @@ pub struct PKInfo {
 pub struct Identity<AccountId> {
     /// The unique identity associated to one account id.
     /// During the AB upgrade, this anchor would keep and won't change.
-    anchor: SworkerAnchor,
-    group: Option<AccountId>
+    pub anchor: SworkerAnchor,
+    pub group: Option<AccountId>
 }
 
 /// An event handler for reporting works
@@ -600,12 +600,6 @@ impl<T: Trait> Module<T> {
         PubKeys::remove(pk);
     }
 
-    /// This function will (maybe) remove pub_keys
-    fn chill_identity(who: &T::AccountId) {
-        // 1. Remove from `identities`
-        <Identities<T>>::remove(who);
-    }
-
     /// This function will chill WorkReports and ReportedInSlot
     fn chill_anchor(anchor: &SworkerAnchor) {
         WorkReports::remove(anchor);
@@ -673,11 +667,10 @@ impl<T: Trait> Module<T> {
         changed_files: &Vec<(MerkleRoot, u64, u64)>,
         anchor: &SworkerPubKey,
         is_added: bool) -> Vec<(MerkleRoot, u64, u64)> {
-        let mut real_files = vec![];
 
         // 1. Loop changed files
         if is_added {
-            real_files = changed_files.iter().filter_map(|(cid, size, valid_at)| {
+            changed_files.iter().filter_map(|(cid, size, valid_at)| {
                 let mut members = None;
                 if let Some(identity) = Self::identities(reporter) {
                     if let Some(owner) = identity.group {
@@ -689,19 +682,18 @@ impl<T: Trait> Module<T> {
                 } else {
                     None
                 }
-            }).collect();
+            }).collect()
         } else {
             let curr_bn = Self::get_current_block_number();
-            real_files = changed_files.iter().filter_map(|(cid, size, _)| {
+            changed_files.iter().filter_map(|(cid, size, _)| {
                 // 2. If mapping to storage orders
                 if T::MarketInterface::delete_replicas(reporter, cid, anchor, curr_bn) {
                     Some((cid.clone(), *size, curr_bn as u64))
                 } else {
                     None
                 }
-            }).collect();
+            }).collect()
         }
-        real_files
     }
 
     /// Get workload by reporter account,

--- a/cstrml/swork/src/tests.rs
+++ b/cstrml/swork/src/tests.rs
@@ -7,7 +7,6 @@ use frame_support::{
 };
 use hex;
 use keyring::Sr25519Keyring;
-use primitives::Hash;
 
 /// Register test cases
 #[test]
@@ -31,10 +30,12 @@ fn register_should_work() {
 
         let legal_code = LegalCode::get();
         let legal_pk = LegalPK::get();
-        let legal_bonded_ids = vec![legal_pk.clone()];
 
-        assert_eq!(Swork::identities(legal_pk).unwrap(), legal_code);
-        assert_eq!(Swork::id_bonds(applier), legal_bonded_ids);
+        assert_eq!(Swork::identities(applier).is_none(), true);
+        assert_eq!(Swork::pub_keys(legal_pk), PKInfo {
+            code: legal_code,
+            anchor: None
+        });
     });
 }
 
@@ -220,71 +221,6 @@ fn register_should_failed_with_wrong_code() {
         });
 }
 
-#[test]
-fn chill_idbond_should_work() {
-    ExtBuilder::default()
-        .build()
-        .execute_with(|| {
-            let applier: AccountId =
-                AccountId::from_ss58check("5FqazaU79hjpEMiWTWZx81VjsYFst15eBuSBKdQLgQibD7CX")
-                    .expect("valid ss58 address");
-            let register_info = legal_register_info();
-
-            assert_ok!(Swork::register(
-            Origin::signed(applier.clone()),
-            register_info.ias_sig,
-            register_info.ias_cert,
-            register_info.account_id,
-            register_info.isv_body,
-            register_info.sig
-        ));
-
-            let legal_code = LegalCode::get();
-            let legal_pk = LegalPK::get();
-            let legal_bonded_ids = vec![legal_pk.clone()];
-
-            assert_eq!(Swork::identities(legal_pk.clone()).unwrap(), legal_code);
-            assert_eq!(Swork::id_bonds(applier.clone()), legal_bonded_ids);
-
-            // pk is invalid
-            assert_noop!(
-                Swork::chill_pk(
-                    Origin::signed(applier.clone()),
-                    vec![1]
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 9,
-                    message: Some("IllegalPubKey"),
-                }
-            );
-
-            let bob: AccountId = Sr25519Keyring::Bob.to_account_id();
-
-            // applier is not registered before
-            assert_noop!(
-                Swork::chill_pk(
-                    Origin::signed(bob),
-                    vec![1]
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 9,
-                    message: Some("IllegalPubKey"),
-                }
-            );
-
-            assert_ok!(
-                Swork::chill_pk(
-                    Origin::signed(applier.clone()),
-                    legal_pk.clone()
-                )
-            );
-            assert!(!Identities::contains_key(legal_pk.clone()));
-            assert!(!<IdBonds<Test>>::contains_key(applier.clone()));
-        });
-}
-
 /// Report works test cases
 #[test]
 fn report_works_should_work() {
@@ -301,14 +237,13 @@ fn report_works_should_work() {
                 report_slot: legal_wr_info.block_number,
                 used: legal_wr_info.used,
                 free: legal_wr_info.free,
-                files: legal_wr_info.added_files.clone().into_iter().collect(),
                 reported_files_size: legal_wr_info.used,
                 reported_srd_root: legal_wr_info.srd_root.clone(),
                 reported_files_root: legal_wr_info.files_root.clone()
             };
 
-            register(&reporter, &legal_pk, &LegalCode::get());
-            add_pending_sorders(&reporter);
+            register(&legal_pk, LegalCode::get());
+            add_not_live_files();
 
             // Check workloads before reporting
             assert_eq!(Swork::free(), 0);
@@ -337,16 +272,43 @@ fn report_works_should_work() {
             assert_eq!(Swork::used(), 402868224);
             assert_eq!(Swork::reported_in_slot(&legal_pk, 300), true);
 
+            assert_eq!(Swork::identities(&reporter).unwrap_or_default(), Identity {
+                anchor: legal_pk.clone(),
+                group: None
+            });
+
             // Check same file all been confirmed
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Success);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(2)).unwrap_or_default().status, OrderStatus::Success);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().expired_on, 1303);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(2)).unwrap_or_default().expired_on, 1303);
+            assert_eq!(Market::files(hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap()).unwrap_or_default().0, FileInfo {
+                file_size: 100,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 1000,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: reporter.clone(),
+                    valid_at: 303,
+                    anchor: legal_pk.clone()
+                }]
+            });
+            assert_eq!(Market::files(hex::decode("88cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap()).unwrap_or_default().0, FileInfo {
+                file_size: 100,
+                expired_on: 1303,
+                claimed_at: 303,
+                amount: 1000,
+                expected_replica_count: 4,
+                reported_replica_count: 1,
+                replicas: vec![Replica {
+                    who: reporter,
+                    valid_at: 303,
+                    anchor: legal_pk
+                }]
+            });
         });
 }
 
 #[test]
-fn report_works_should_work_without_sorders() {
+fn report_works_should_work_without_files() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
@@ -357,7 +319,7 @@ fn report_works_should_work_without_sorders() {
             let legal_wr_info = legal_work_report_with_added_files();
             let legal_pk = legal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
 
             // Check workloads before reporting
             assert_eq!(Swork::free(), 0);
@@ -396,7 +358,7 @@ fn report_works_should_work_with_added_and_deleted_files() {
             let legal_wr_info = legal_work_report();
             let legal_pk = legal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
 
             assert_ok!(Swork::report_works(
                 Origin::signed(reporter.clone()),
@@ -419,7 +381,7 @@ fn report_works_should_work_with_added_and_deleted_files() {
             // TODO: use `same size added and deleted files` work report test case
             // FAKE Pass.
             let legal_wr_info_with_added_and_deleted_files = legal_work_report_with_added_and_deleted_files();
-            assert_noop!(
+            assert_ok!(
                 Swork::report_works(
                     Origin::signed(reporter),
                     legal_wr_info_with_added_and_deleted_files.curr_pk,
@@ -433,12 +395,7 @@ fn report_works_should_work_with_added_and_deleted_files() {
                     legal_wr_info_with_added_and_deleted_files.srd_root,
                     legal_wr_info_with_added_and_deleted_files.files_root,
                     legal_wr_info_with_added_and_deleted_files.sig
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 5,
-                    message: Some("IllegalWorkReportSig"),
-                }
+                )
             );
         });
 }
@@ -492,7 +449,7 @@ fn report_works_should_failed_with_illegal_code() {
             let illegal_code = hex::decode("0011").unwrap();
 
             // register with
-            register(&reporter, &legal_pk, &illegal_code);
+            register(&legal_pk, illegal_code);
 
             assert_noop!(
                 Swork::report_works(
@@ -530,7 +487,7 @@ fn report_works_should_failed_with_wrong_timing() {
             let illegal_wr_info = legal_work_report_with_added_files();
             let legal_pk = illegal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
 
             assert_noop!(
                 Swork::report_works(
@@ -569,7 +526,7 @@ fn report_works_should_failed_with_illegal_sig() {
             let legal_pk = illegal_wr_info.curr_pk.clone();
             illegal_wr_info.sig = hex::decode("b3f78863ec972955d9ca22d444a5475085a4f7975a738aba1eae1d98dd718fc691a77a35b764a148a3a861a4a2ef3279f3d5e25f607c73ca85ea86e1176ba664").unwrap();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
 
             assert_noop!(
                 Swork::report_works(
@@ -607,14 +564,14 @@ fn report_works_should_failed_with_illegal_file_transition() {
             let illegal_wr_info = legal_work_report_with_added_files();
             let legal_pk = illegal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
 
             // Add initial work report with `reported_files_size = 5`
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 0,
                 free: 0,
-                files: Default::default(),
                 reported_files_size: 5,
                 reported_srd_root: vec![],
                 reported_files_root: vec![]
@@ -657,15 +614,12 @@ fn incremental_report_should_work_without_change() {
             let legal_wr_info = legal_work_report();
             let legal_pk = legal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
@@ -704,26 +658,21 @@ fn incremental_report_should_work_with_files_change() {
                 report_slot: legal_wr_info.block_number,
                 used: legal_wr_info.used,
                 free: legal_wr_info.free,
-                files: legal_wr_info.added_files.clone().into_iter().collect(),
                 reported_files_size: legal_wr_info.used,
                 reported_srd_root: legal_wr_info.srd_root.clone(),
                 reported_files_root: legal_wr_info.files_root.clone()
             };
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 3,
                 reported_srd_root: vec![],
                 reported_files_root: vec![]
             });
-            add_success_sorders(&reporter);
+            add_live_files(&reporter, &legal_pk);
 
             assert_ok!(Swork::report_works(
                 Origin::signed(reporter.clone()),
@@ -747,11 +696,6 @@ fn incremental_report_should_work_with_files_change() {
             assert_eq!(Swork::free(), 4294967296);
             assert_eq!(Swork::used(), 0);
 
-            // Check same file all been confirmed
-            // We only test Success -> Failed here
-            // Another case(Pending -> Success) already tested in `report_works_should_work` case
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Failed);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Failed);
         });
 }
 
@@ -767,15 +711,12 @@ fn incremental_report_should_failed_with_root_change() {
             let illegal_wr_info = legal_work_report();
             let legal_pk = illegal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: vec![],
                 reported_files_root: vec![]
@@ -818,15 +759,12 @@ fn incremental_report_should_failed_with_wrong_file_size_change() {
             let legal_pk = illegal_wr_info.curr_pk.clone();
 
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 40,
                 free: 40,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 20),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 20)
-                ].into_iter().collect(),
                 reported_files_size: 40,
                 reported_srd_root: vec![],
                 reported_files_root: vec![]
@@ -866,20 +804,17 @@ fn update_identities_should_work() {
             let legal_wr_info = legal_work_report();
             let legal_pk = legal_wr_info.curr_pk.clone();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
             });
-            add_success_sorders(&reporter);
+            add_live_files(&reporter, &legal_pk);
 
             // 1. Runs to 303 block
             run_to_block(303);
@@ -888,6 +823,7 @@ fn update_identities_should_work() {
             assert_eq!(Swork::free(), 0);
             assert_eq!(Swork::used(), 2);
             assert_eq!(Swork::current_report_slot(), 300);
+            assert_eq!(*WorkloadMap::get().borrow().get(&reporter).unwrap(), 2u128);
 
             // 2. Report works in slot 300
             assert_ok!(Swork::report_works(
@@ -908,6 +844,7 @@ fn update_identities_should_work() {
             // 3. Free and used should already been updated
             assert_eq!(Swork::free(), 4294967296);
             assert_eq!(Swork::used(), 2);
+            assert_eq!(*WorkloadMap::get().borrow().get(&reporter).unwrap(), 2u128);
 
             // 4. Runs to 606
             run_to_block(606);
@@ -917,6 +854,7 @@ fn update_identities_should_work() {
             assert_eq!(Swork::free(), 4294967296);
             assert_eq!(Swork::used(), 2);
             assert_eq!(Swork::current_report_slot(), 600);
+            assert_eq!(*WorkloadMap::get().borrow().get(&reporter).unwrap(), 4294967298u128);
 
             // 6. Runs to 909, work report is outdated
             run_to_block(909);
@@ -926,74 +864,7 @@ fn update_identities_should_work() {
             assert_eq!(Swork::free(), 0);
             assert_eq!(Swork::used(), 0);
             assert_eq!(Swork::current_report_slot(), 900);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Failed);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Failed);
-        });
-}
-
-#[test]
-fn resuming_report_should_work() {
-    ExtBuilder::default()
-        .build()
-        .execute_with(|| {
-            let reporter: AccountId = Sr25519Keyring::Alice.to_account_id();
-            let legal_wr_info = resuming_work_report();
-            let legal_pk = legal_wr_info.curr_pk.clone();
-
-            register(&reporter, &legal_pk, &LegalCode::get());
-            add_wr(&legal_pk, &WorkReport {
-                report_slot: 0,
-                used: 2,
-                free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
-                reported_files_size: 2,
-                reported_srd_root: hex::decode("00").unwrap(),
-                reported_files_root: hex::decode("11").unwrap()
-            });
-            add_success_sorders(&reporter);
-
-            // 1. Runs to 303 block
-            run_to_block(303);
-            Swork::update_identities();
-
-            // 2. No works reported, but orders should still be ok
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Success);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Success);
-
-            // 3. Runs to 606
-            run_to_block(606);
-            Swork::update_identities();
-
-            // 4. Storage order should still be success
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Failed);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Failed);
-
-            // 5. Runs to 909, work report is outdated
-            run_to_block(909);
-            Swork::update_identities();
-
-            // 6. Report works in slot 900
-            assert_ok!(Swork::report_works(
-                Origin::signed(reporter.clone()),
-                legal_wr_info.curr_pk,
-                legal_wr_info.prev_pk,
-                legal_wr_info.block_number,
-                legal_wr_info.block_hash,
-                legal_wr_info.free,
-                legal_wr_info.used,
-                legal_wr_info.added_files,
-                legal_wr_info.deleted_files,
-                legal_wr_info.srd_root,
-                legal_wr_info.files_root,
-                legal_wr_info.sig
-            ));
-
-            // 7. Orders should reset back
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Success);
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Success);
+            assert_eq!(*WorkloadMap::get().borrow().get(&reporter).unwrap(), 0u128);
         });
 }
 
@@ -1005,20 +876,17 @@ fn abnormal_era_should_work() {
             let reporter: AccountId = Sr25519Keyring::Alice.to_account_id();
             let legal_pk = LegalPK::get();
 
-            register(&reporter, &legal_pk, &LegalCode::get());
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
             add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
             });
-            add_success_sorders(&reporter);
+            add_live_files(&reporter, &legal_pk);
 
             // 1. Normal new era, runs to 301 block
             run_to_block(301);
@@ -1052,21 +920,18 @@ fn ab_upgrade_should_work() {
             let b_pk = b_wr_info_1.curr_pk.clone();
 
             // 0. Initial setup
-            register(&reporter, &a_pk, &LegalCode::get());
+            register(&a_pk, LegalCode::get());
+            register_identity(&reporter, &a_pk, &a_pk);
             add_wr(&a_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
             });
-            add_pending_sorders(&reporter); // with b_wr_info_2's added file
-            add_success_sorders(&reporter); // with b_wr_info_2's deleted file
+            add_not_live_files(); // with b_wr_info_2's added file
+            add_live_files(&reporter, &a_pk); // with b_wr_info_2's deleted file
 
             // 1. Runs to 303 block
             run_to_block(303);
@@ -1092,10 +957,6 @@ fn ab_upgrade_should_work() {
                 report_slot: 300,
                 used: 2,
                 free: 4294967296,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
@@ -1110,7 +971,7 @@ fn ab_upgrade_should_work() {
             // Fake do upgrade
 
             // 5. (Fake) Register B 🤣, suppose B's code is upgraded
-            register(&reporter, &b_pk, &LegalCode::get());
+            register(&b_pk, LegalCode::get());
 
             // 6. Report works with sWorker B
             assert_ok!(Swork::report_works(
@@ -1129,28 +990,21 @@ fn ab_upgrade_should_work() {
             ));
 
             // 7. Check B's work report and free & used
-            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+            assert_eq!(Swork::work_reports(&a_pk).unwrap(), WorkReport {
                 report_slot: 600,
                 used: 2,
                 free: 4294967296,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
             });
             assert_eq!(Swork::free(), 4294967296);
             assert_eq!(Swork::used(), 2);
-            assert_eq!(Swork::reported_in_slot(&b_pk, 300), true);
-            assert_eq!(Swork::reported_in_slot(&b_pk, 600), true);
+            assert_eq!(Swork::reported_in_slot(&a_pk, 300), true);
+            assert_eq!(Swork::reported_in_slot(&a_pk, 600), true);
 
             // 8. Check A is already be chilled
-            assert_eq!(Swork::identities(&a_pk), None);
-            assert_eq!(Swork::work_reports(&a_pk), None);
-            assert_eq!(Swork::id_bonds(&reporter), vec![b_pk.clone()]);
-            assert_eq!(Swork::reported_in_slot(&a_pk, 300), false);
+            assert_eq!(<self::PubKeys>::contains_key(&a_pk), false);
 
             // 9. Runs to 909
             run_to_block(909);
@@ -1172,26 +1026,16 @@ fn ab_upgrade_should_work() {
             ));
 
             // 11. Check B's work report and free & used again
-            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+            assert_eq!(Swork::work_reports(&a_pk).unwrap(), WorkReport {
                 report_slot: 900,
                 used: 3,
                 free: 4294967296,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 2)
-                ].into_iter().collect(),
                 reported_files_size: 3,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
             });
             assert_eq!(Swork::free(), 4294967296);
             assert_eq!(Swork::used(), 3); // Added 2 and delete 1
-
-            // 12. Corresponding sorder should work
-            // 5bb706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(0)).unwrap_or_default().status, OrderStatus::Success);
-            // 99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f
-            assert_eq!(Market::sorder_statuses(Hash::repeat_byte(1)).unwrap_or_default().status, OrderStatus::Failed);
         });
 }
 
@@ -1206,15 +1050,12 @@ fn ab_upgrade_expire_should_work() {
             let legal_pk = wr_info_300.curr_pk.clone();
 
             // 0. Initial setup
-            register(&reporter, &legal_pk, &LegalCode::get());
-            add_wr(&legal_pk, &&WorkReport {
+            register(&legal_pk, LegalCode::get());
+            register_identity(&reporter, &legal_pk, &legal_pk);
+            add_wr(&legal_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
@@ -1277,20 +1118,16 @@ fn ab_upgrade_should_failed_with_files_size_unmatch() {
         .execute_with(|| {
             let reporter: AccountId = Sr25519Keyring::Alice.to_account_id();
             let a_wr_info = legal_work_report();
-            let mut b_wr_info = ab_upgrade_work_report();
+            let b_wr_info = ab_upgrade_work_report_files_size_unmatch();
             let a_pk = a_wr_info.curr_pk.clone();
             let b_pk = b_wr_info.curr_pk.clone();
 
             // 0. Initial setup
-            register(&reporter, &a_pk, &LegalCode::get());
+            register(&a_pk, LegalCode::get());
             add_wr(&a_pk, &WorkReport {
                 report_slot: 0,
                 used: 2,
                 free: 0,
-                files: vec![
-                    (hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 1),
-                    (hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(), 1)
-                ].into_iter().collect(),
                 reported_files_size: 2,
                 reported_srd_root: hex::decode("00").unwrap(),
                 reported_files_root: hex::decode("11").unwrap()
@@ -1313,17 +1150,14 @@ fn ab_upgrade_should_failed_with_files_size_unmatch() {
                 a_wr_info.sig
             ));
 
-            // 2. Report B with added_files
-            b_wr_info.added_files = vec![(hex::decode("6aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(), 10)];
-
-            // 4. Runs to 606, and do sWorker upgrade
+            // 2. Runs to 606, and do sWorker upgrade
             run_to_block(606);
             // Fake do upgrade
 
-            // 5. (Fake) Register B 🤣, suppose B's code is upgraded
-            register(&reporter, &b_pk, &LegalCode::get());
+            // 3. (Fake) Register B 🤣, suppose B's code is upgraded
+            register(&b_pk, LegalCode::get());
 
-            // 6. Report works with sWorker B will failed
+            // 4. Report works with sWorker B will failed
             assert_noop!(
                 Swork::report_works(
                     Origin::signed(reporter.clone()),
@@ -1348,102 +1182,890 @@ fn ab_upgrade_should_failed_with_files_size_unmatch() {
         });
 }
 
-/// Star network test cases
-/// As for the star network, more should be tested in market module(space size) and staking module(stake limit)
+/// Group test cases
 #[test]
-fn multiple_bonds_should_work() {
+fn join_group_should_work() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
-            let reporter = Sr25519Keyring::Alice.to_account_id();
-            let wr_info_1 = legal_work_report();
-            let wr_info_2 = legal_work_report_with_added_files();
-            let pk1 = wr_info_1.curr_pk.clone();
-            let pk2 = wr_info_2.curr_pk.clone();
+            let alice = Sr25519Keyring::Alice.to_account_id();
+            let bob = Sr25519Keyring::Bob.to_account_id();
 
-            register(&reporter, &pk1, &LegalCode::get());
-            register(&reporter, &pk2, &LegalCode::get());
+            // Prepare two work reports
+            let a_wr_info = legal_work_report();
+            let b_wr_info = ab_upgrade_work_report();
+            let a_pk = a_wr_info.curr_pk.clone();
+            let b_pk = b_wr_info.curr_pk.clone();
 
-            assert_eq!(Swork::id_bonds(&reporter), vec![pk1.clone(), pk2.clone()]);
+            register_identity(&alice, &a_pk, &a_pk);
+            register_identity(&bob, &b_pk, &b_pk);
+
+            add_wr(&a_pk, &WorkReport {
+                report_slot: 0,
+                used: 2000,
+                free: 0,
+                reported_files_size: 2,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+            add_wr(&b_pk, &WorkReport {
+                report_slot: 0,
+                used: 0,
+                free: 0,
+                reported_files_size: 2,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            // Alice create a group and be the owner
+            assert_ok!(Swork::join_group(
+                Origin::signed(alice.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&alice).unwrap_or_default(), Identity {
+                anchor: a_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            // Bob join the alice's group
+            assert_ok!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&bob).unwrap_or_default(), Identity {
+                anchor: b_pk.clone(),
+                group: Some(alice.clone())
+            });
         });
 }
 
 #[test]
-fn bonds_limit_should_work() {
+fn join_group_should_failed_due_to_invalid_situations() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
-            let applier = AccountId::from_ss58check("5FqazaU79hjpEMiWTWZx81VjsYFst15eBuSBKdQLgQibD7CX")
-                .expect("valid ss58 address");
-            let legal_register_info = legal_register_info();
+            let alice = Sr25519Keyring::Alice.to_account_id();
+            let bob = Sr25519Keyring::Bob.to_account_id();
 
-            register(&applier, &vec![], &LegalCode::get());
-            register(&applier, &vec![], &LegalCode::get());
+            let a_wr_info = legal_work_report();
+            let b_wr_info = ab_upgrade_work_report();
+            let a_pk = a_wr_info.curr_pk.clone();
+            let b_pk = b_wr_info.curr_pk.clone();
 
-            assert_noop!(
-                Swork::register(
-                    Origin::signed(applier.clone()),
-                    legal_register_info.ias_sig,
-                    legal_register_info.ias_cert,
-                    legal_register_info.account_id,
-                    legal_register_info.isv_body,
-                    legal_register_info.sig
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 8,
-                    message: Some("ExceedBondsLimit"),
-                }
-            );
+            // bob's identity doesn't exist
+            assert_noop!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 10,
+                message: Some("IdentityNotExist"),
+            });
+
+
+            register_identity(&bob, &b_pk, &b_pk);
+            // alice's identity doesn't exist
+            assert_noop!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 10,
+                message: Some("IdentityNotExist"),
+            });
+
+            register_identity(&alice, &a_pk, &a_pk);
+
+            add_wr(&a_pk, &WorkReport {
+                report_slot: 0,
+                used: 2000,
+                free: 0,
+                reported_files_size: 2,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+            add_wr(&b_pk, &WorkReport {
+                report_slot: 0,
+                used: 100,
+                free: 0,
+                reported_files_size: 2,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            // alice is not the owner of the group
+            assert_noop!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 12,
+                message: Some("NotOwner"),
+            });
+
+            // Alice create a group and be the owner
+            assert_ok!(Swork::join_group(
+                Origin::signed(alice.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&alice).unwrap_or_default(), Identity {
+                anchor: a_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            // bob's used is not 0
+            assert_noop!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 13,
+                message: Some("IllegalUsed"),
+            });
+
+            add_wr(&b_pk, &WorkReport {
+                report_slot: 0,
+                used: 0,
+                free: 0,
+                reported_files_size: 2,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            // Bob join the alice's group
+            assert_ok!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&bob).unwrap_or_default(), Identity {
+                anchor: b_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            // bob already joined a group
+            assert_noop!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 11,
+                message: Some("AlreadyJoint"),
+            });
         });
 }
 
 #[test]
-fn bonds_limit_during_upgrade_should_work() {
+fn join_group_should_work_for_used_in_work_report() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
-            let applier = AccountId::from_ss58check("5FqazaU79hjpEMiWTWZx81VjsYFst15eBuSBKdQLgQibD7CX")
-                .expect("valid ss58 address");
-            let failed_legal_register_info = legal_register_info();
+            let alice = Sr25519Keyring::Alice.to_account_id();
+            let bob = Sr25519Keyring::Bob.to_account_id();
+            let eve = Sr25519Keyring::Eve.to_account_id();
 
-            register(&applier, &vec![0], &LegalCode::get());
-            register(&applier, &vec![1], &LegalCode::get());
+            // Get work report in 300 slot fo alice, bob and eve
+            let alice_wr_info = group_work_report_alice_300();
+            let bob_wr_info = group_work_report_bob_300();
+            let eve_wr_info = group_work_report_eve_300();
+            let a_pk = alice_wr_info.curr_pk.clone();
+            let b_pk = bob_wr_info.curr_pk.clone();
+            let c_pk = eve_wr_info.curr_pk.clone();
 
-            assert_noop!(
-                Swork::register(
-                    Origin::signed(applier.clone()),
-                    failed_legal_register_info.ias_sig,
-                    failed_legal_register_info.ias_cert,
-                    failed_legal_register_info.account_id,
-                    failed_legal_register_info.isv_body,
-                    failed_legal_register_info.sig
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 8,
-                    message: Some("ExceedBondsLimit"),
-                }
+            register(&a_pk, LegalCode::get());
+            register(&b_pk, LegalCode::get());
+            register(&c_pk, LegalCode::get());
+            register_identity(&alice, &a_pk, &a_pk);
+            register_identity(&bob, &b_pk, &b_pk);
+            register_identity(&eve, &c_pk, &c_pk);
+
+            // We have five test files
+            let file_a = hex::decode("5aa706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b660").unwrap(); // A file
+            let file_b = hex::decode("99cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(); // B file
+            let file_c = hex::decode("77cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae65f").unwrap(); // C file
+            let file_d = hex::decode("66a706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b110").unwrap(); // D file
+            let file_e = hex::decode("33cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae12e").unwrap(); // E file
+
+            // alice, bob and eve become a group
+            assert_ok!(Swork::join_group(
+                Origin::signed(alice.clone()),
+                alice.clone()
+            ));
+            assert_ok!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ));
+            assert_ok!(Swork::join_group(
+                Origin::signed(eve.clone()),
+                alice.clone()
+            ));
+
+            run_to_block(303);
+            add_not_live_files();
+            // A report works in 303
+            assert_ok!(Swork::report_works(
+                Origin::signed(alice.clone()),
+                alice_wr_info.curr_pk,
+                alice_wr_info.prev_pk,
+                alice_wr_info.block_number,
+                alice_wr_info.block_hash,
+                alice_wr_info.free,
+                alice_wr_info.used,
+                alice_wr_info.added_files,
+                alice_wr_info.deleted_files,
+                alice_wr_info.srd_root,
+                alice_wr_info.files_root,
+                alice_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_a).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 13,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![Replica {
+                        who: alice.clone(),
+                        valid_at: 303,
+                        anchor: a_pk.clone()
+                    }]
+                },
+                UsedInfo {
+                    used_size: 13,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_b).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 7,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![Replica {
+                        who: alice.clone(),
+                        valid_at: 303,
+                        anchor: a_pk.clone()
+                    }]
+                },
+                UsedInfo {
+                    used_size: 7,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_c).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 37,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![Replica {
+                        who: alice.clone(),
+                        valid_at: 303,
+                        anchor: a_pk.clone()
+                    }]
+                },
+                UsedInfo {
+                    used_size: 37,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Swork::work_reports(&a_pk).unwrap(), WorkReport {
+                report_slot: 300,
+                used: 57,
+                free: 4294967296,
+                reported_files_size: 57,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(bob.clone()),
+                bob_wr_info.curr_pk,
+                bob_wr_info.prev_pk,
+                bob_wr_info.block_number,
+                bob_wr_info.block_hash,
+                bob_wr_info.free,
+                bob_wr_info.used,
+                bob_wr_info.added_files,
+                bob_wr_info.deleted_files,
+                bob_wr_info.srd_root,
+                bob_wr_info.files_root,
+                bob_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_b).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 7,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 2,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        },
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 7,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_c).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 37,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 2,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        },
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 37,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
             );
 
-            assert_ok!(Swork::upgrade(Origin::root(), hex::decode("0011").unwrap(), 500));
-
-            // TODO: Use success register info later. Fake the test for now.
-            let legal_register_info = legal_register_info();
-            assert_noop!(
-                Swork::register(
-                    Origin::signed(applier.clone()),
-                    legal_register_info.ias_sig,
-                    legal_register_info.ias_cert,
-                    legal_register_info.account_id,
-                    legal_register_info.isv_body,
-                    legal_register_info.sig
-                ),
-                DispatchError::Module {
-                    index: 0,
-                    error: 1,
-                    message: Some("IllegalIdentity"),
-                }
+            assert_eq!(Market::files(&file_d).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 55,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 55,
+                    anchors: BTreeSet::from_iter(vec![b_pk.clone()].into_iter())
+                })
             );
+            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+                report_slot: 300,
+                used: 55,
+                free: 4294967296,
+                reported_files_size: 99,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(eve.clone()),
+                eve_wr_info.curr_pk,
+                eve_wr_info.prev_pk,
+                eve_wr_info.block_number,
+                eve_wr_info.block_hash,
+                eve_wr_info.free,
+                eve_wr_info.used,
+                eve_wr_info.added_files,
+                eve_wr_info.deleted_files,
+                eve_wr_info.srd_root,
+                eve_wr_info.files_root,
+                eve_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_c).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 37,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 3,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        },
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        },
+                        Replica {
+                            who: eve.clone(),
+                            valid_at: 303,
+                            anchor: c_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 37,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_d).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 55,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 2,
+                    replicas: vec![
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        },
+                        Replica {
+                            who: eve.clone(),
+                            valid_at: 303,
+                            anchor: c_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 55,
+                    anchors: BTreeSet::from_iter(vec![b_pk.clone()].into_iter())
+                })
+            );
+
+            assert_eq!(Market::files(&file_e).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 22,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![
+                        Replica {
+                            who: eve.clone(),
+                            valid_at: 303,
+                            anchor: c_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 22,
+                    anchors: BTreeSet::from_iter(vec![c_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Swork::work_reports(&c_pk).unwrap(), WorkReport {
+                report_slot: 300,
+                used: 22,
+                free: 4294967296,
+                reported_files_size: 114,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            let bob_wr_info = group_work_report_bob_600();
+            let eve_wr_info = group_work_report_eve_600();
+
+            run_to_block(603);
+            assert_ok!(Swork::report_works(
+                Origin::signed(bob.clone()),
+                bob_wr_info.curr_pk,
+                bob_wr_info.prev_pk,
+                bob_wr_info.block_number,
+                bob_wr_info.block_hash,
+                bob_wr_info.free,
+                bob_wr_info.used,
+                bob_wr_info.added_files,
+                bob_wr_info.deleted_files,
+                bob_wr_info.srd_root,
+                bob_wr_info.files_root,
+                bob_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_b).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 7,
+                    expired_on: 1303,
+                    claimed_at: 603,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 7,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_c).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 37,
+                    expired_on: 1303,
+                    claimed_at: 603,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 2,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        },
+                        Replica {
+                            who: eve.clone(),
+                            valid_at: 303,
+                            anchor: c_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 37,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+
+            assert_eq!(Market::files(&file_d).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 55,
+                    expired_on: 1303,
+                    claimed_at: 303,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 2,
+                    replicas: vec![
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        },
+                        Replica {
+                            who: eve.clone(),
+                            valid_at: 303,
+                            anchor: c_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 55,
+                    anchors: BTreeSet::from_iter(vec![b_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+                report_slot: 600,
+                used: 55,
+                free: 4294967296,
+                reported_files_size: 55,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(eve.clone()),
+                eve_wr_info.curr_pk,
+                eve_wr_info.prev_pk,
+                eve_wr_info.block_number,
+                eve_wr_info.block_hash,
+                eve_wr_info.free,
+                eve_wr_info.used,
+                eve_wr_info.added_files,
+                eve_wr_info.deleted_files,
+                eve_wr_info.srd_root,
+                eve_wr_info.files_root,
+                eve_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_c).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 37,
+                    expired_on: 1303,
+                    claimed_at: 603,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![
+                        Replica {
+                            who: alice.clone(),
+                            valid_at: 303,
+                            anchor: a_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 37,
+                    anchors: BTreeSet::from_iter(vec![a_pk.clone()].into_iter())
+                })
+            );
+            assert_eq!(Market::files(&file_d).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 55,
+                    expired_on: 1303,
+                    claimed_at: 603,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 1,
+                    replicas: vec![
+                        Replica {
+                            who: bob.clone(),
+                            valid_at: 303,
+                            anchor: b_pk.clone()
+                        }
+                    ]
+                },
+                UsedInfo {
+                    used_size: 55,
+                    anchors: BTreeSet::from_iter(vec![b_pk.clone()].into_iter())
+                })
+            );
+
+            assert_eq!(Market::files(&file_e).unwrap_or_default(), (
+                FileInfo {
+                    file_size: 22,
+                    expired_on: 1303,
+                    claimed_at: 603,
+                    amount: 1000,
+                    expected_replica_count: 4,
+                    reported_replica_count: 0,
+                    replicas: vec![]
+                },
+                UsedInfo {
+                    used_size: 22,
+                    anchors: BTreeSet::from_iter(vec![].into_iter())
+                })
+            );
+            assert_eq!(Swork::work_reports(&c_pk).unwrap(), WorkReport {
+                report_slot: 600,
+                used: 0,
+                free: 4294967296,
+                reported_files_size: 0,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            run_to_block(1500);
+            let alice_wr_info = group_work_report_alice_1500();
+            assert_ok!(Market::calculate_reward(Origin::signed(eve.clone()), file_c.clone()));
+            assert_ok!(Market::calculate_reward(Origin::signed(eve.clone()), file_d.clone()));
+            assert_ok!(Market::calculate_reward(Origin::signed(eve.clone()), file_e.clone()));
+            // A, B still open, C, D, E already close. Trash I is full. Trash II has one file. Now we report works of alice to close A, B as well.
+            assert_eq!(Market::files(&file_c), None);
+            assert_eq!(Market::files(&file_d), None);
+            assert_eq!(Market::files(&file_e), None);
+
+            assert_eq!(Market::used_trash_i(&file_c).is_some(), true);
+            assert_eq!(Market::used_trash_i(&file_d).is_some(), true);
+            assert_eq!(Market::used_trash_ii(&file_e).is_some(), true);
+
+            assert_eq!(Swork::work_reports(&a_pk).unwrap(), WorkReport {
+                report_slot: 300,
+                used: 57,
+                free: 4294967296,
+                reported_files_size: 57,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+                report_slot: 600,
+                used: 55,
+                free: 4294967296,
+                reported_files_size: 55,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(alice.clone()),
+                alice_wr_info.curr_pk,
+                alice_wr_info.prev_pk,
+                alice_wr_info.block_number,
+                alice_wr_info.block_hash,
+                alice_wr_info.free,
+                alice_wr_info.used,
+                alice_wr_info.added_files,
+                alice_wr_info.deleted_files,
+                alice_wr_info.srd_root,
+                alice_wr_info.files_root,
+                alice_wr_info.sig
+            ));
+
+            assert_eq!(Market::files(&file_a), None);
+            assert_eq!(Market::files(&file_b), None);
+            assert_eq!(Market::used_trash_i(&file_b).is_some(), true);
+            assert_eq!(Market::used_trash_ii(&file_e).is_some(), true);
+            assert_eq!(Market::used_trash_ii(&file_a).is_some(), true);
+            assert_eq!(Market::used_trash_i(&file_c).is_none(), true);
+            assert_eq!(Market::used_trash_i(&file_d).is_none(), true);
+
+            // d has gone!
+            assert_eq!(Swork::work_reports(&b_pk).unwrap(), WorkReport {
+                report_slot: 600,
+                used: 0,
+                free: 4294967296,
+                reported_files_size: 55,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+
+            assert_eq!(Swork::work_reports(&a_pk).unwrap(), WorkReport {
+                report_slot: 1500,
+                used: 0,
+                free: 4294967296,
+                reported_files_size: 0,
+                reported_srd_root: hex::decode("00").unwrap(),
+                reported_files_root: hex::decode("11").unwrap()
+            });
+        });
+}
+
+
+#[test]
+fn join_group_should_work_for_stake_limit() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(|| {
+            let alice = Sr25519Keyring::Alice.to_account_id();
+            let bob = Sr25519Keyring::Bob.to_account_id();
+            let eve = Sr25519Keyring::Eve.to_account_id();
+
+            let alice_wr_info = group_work_report_alice_300();
+            let bob_wr_info = group_work_report_bob_300();
+            let eve_wr_info = group_work_report_eve_300();
+            let a_pk = alice_wr_info.curr_pk.clone();
+            let b_pk = bob_wr_info.curr_pk.clone();
+            let c_pk = eve_wr_info.curr_pk.clone();
+
+            register(&a_pk, LegalCode::get());
+            register(&b_pk, LegalCode::get());
+            register(&c_pk, LegalCode::get());
+            register_identity(&alice, &a_pk, &a_pk);
+            register_identity(&bob, &b_pk, &b_pk);
+            register_identity(&eve, &c_pk, &c_pk);
+
+            assert_ok!(Swork::join_group(
+                Origin::signed(alice.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&alice).unwrap_or_default(), Identity {
+                anchor: a_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            assert_ok!(Swork::join_group(
+                Origin::signed(bob.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&bob).unwrap_or_default(), Identity {
+                anchor: b_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            assert_ok!(Swork::join_group(
+                Origin::signed(eve.clone()),
+                alice.clone()
+            ));
+
+            assert_eq!(Swork::identities(&eve).unwrap_or_default(), Identity {
+                anchor: c_pk.clone(),
+                group: Some(alice.clone())
+            });
+
+            run_to_block(303);
+            Swork::update_identities();
+            add_not_live_files();
+            // A report works in 303
+            assert_ok!(Swork::report_works(
+                Origin::signed(alice.clone()),
+                alice_wr_info.curr_pk,
+                alice_wr_info.prev_pk,
+                alice_wr_info.block_number,
+                alice_wr_info.block_hash,
+                alice_wr_info.free,
+                alice_wr_info.used,
+                alice_wr_info.added_files,
+                alice_wr_info.deleted_files,
+                alice_wr_info.srd_root,
+                alice_wr_info.files_root,
+                alice_wr_info.sig
+            ));
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(bob.clone()),
+                bob_wr_info.curr_pk,
+                bob_wr_info.prev_pk,
+                bob_wr_info.block_number,
+                bob_wr_info.block_hash,
+                bob_wr_info.free,
+                bob_wr_info.used,
+                bob_wr_info.added_files,
+                bob_wr_info.deleted_files,
+                bob_wr_info.srd_root,
+                bob_wr_info.files_root,
+                bob_wr_info.sig
+            ));
+
+            assert_ok!(Swork::report_works(
+                Origin::signed(eve.clone()),
+                eve_wr_info.curr_pk,
+                eve_wr_info.prev_pk,
+                eve_wr_info.block_number,
+                eve_wr_info.block_hash,
+                eve_wr_info.free,
+                eve_wr_info.used,
+                eve_wr_info.added_files,
+                eve_wr_info.deleted_files,
+                eve_wr_info.srd_root,
+                eve_wr_info.files_root,
+                eve_wr_info.sig
+            ));
+
+            run_to_block(603);
+            Swork::update_identities();
+
+            assert_eq!(Swork::free(), 12884901888);
+            assert_eq!(Swork::used(), 134);
+            assert_eq!(Swork::current_report_slot(), 600);
+            let map = WorkloadMap::get().borrow().clone();
+            // All workload is counted to alice. bob and eve is None.
+            assert_eq!(*map.get(&alice).unwrap(), 12884902022u128);
+            assert_eq!(map.get(&bob).is_none(), true);
+            assert_eq!(map.get(&eve).is_none(), true);
         });
 }

--- a/cstrml/swork/src/utils.rs
+++ b/cstrml/swork/src/utils.rs
@@ -144,13 +144,15 @@ pub fn verify_identity (
     None
 }
 
-pub fn encode_files(fs: &Vec<(Vec<u8>, u64)>) -> Vec<u8> {
+pub fn encode_files(fs: &Vec<(Vec<u8>, u64, u64)>) -> Vec<u8> {
     // "["
     let open_square_brackets_bytes: Vec<u8> = [91].to_vec();
-    // "\"hash\":\""
-    let hash_bytes: Vec<u8> = [123, 34, 104, 97, 115,104, 34, 58, 34].to_vec();
+    // "{\"cid\":\""
+    let cid_bytes: Vec<u8> = [123, 34, 99, 105, 100, 34, 58, 34].to_vec();
     // "\",\"size\":"
     let size_bytes: Vec<u8> = [34, 44, 34, 115, 105, 122, 101, 34, 58].to_vec();
+    // ",\"c_block_num\":"
+    let block_num_bytes: Vec<u8> = [44, 34, 99, 95, 98, 108, 111, 99, 107, 95, 110, 117, 109, 34, 58].to_vec();
     // "}"
     let close_curly_brackets_bytes: Vec<u8> = [125].to_vec();
     // ","
@@ -159,11 +161,13 @@ pub fn encode_files(fs: &Vec<(Vec<u8>, u64)>) -> Vec<u8> {
     let close_square_brackets_bytes: Vec<u8> = [93].to_vec();
     let mut rst: Vec<u8> = open_square_brackets_bytes.clone();
     let len = fs.len();
-    for (pos, (hash, size)) in fs.iter().enumerate() {
-        rst.extend(hash_bytes.clone());
+    for (pos, (hash, size, block_num)) in fs.iter().enumerate() {
+        rst.extend(cid_bytes.clone());
         rst.extend(encode_file_root(hash.clone()));
         rst.extend(size_bytes.clone());
         rst.extend(encode_u64_to_string_to_bytes(*size));
+        rst.extend(block_num_bytes.clone());
+        rst.extend(encode_u64_to_string_to_bytes(*block_num));
         rst.extend(close_curly_brackets_bytes.clone());
         if pos != len-1 { rst.extend(comma_bytes.clone()) }
     }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -52,6 +52,9 @@ pub type SworkerCert = Vec<u8>;
 /// sworker public key, little-endian-format, 64 bytes vec
 pub type SworkerPubKey = Vec<u8>;
 
+/// sworker anchor, just use SworkerPubKey right now, 64 bytes vec
+pub type SworkerAnchor = SworkerPubKey;
+
 /// sworker signature, little-endian-format, 64 bytes vec
 pub type SworkerSignature = Vec<u8>;
 

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -1,6 +1,30 @@
 use frame_support::traits::LockableCurrency;
+use crate::{SworkerAnchor, MerkleRoot, BlockNumber};
+use sp_std::collections::btree_set::BTreeSet;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait TransferrableCurrency<AccountId>: LockableCurrency<AccountId> {
 	fn transfer_balance(who: &AccountId) -> Self::Balance;
+}
+
+/// Means for interacting with a specialized version of the `swork` trait.
+pub trait SworkerInterface<AccountId> {
+	// Check whether work report was reported in the last report slot according to given block number
+	fn is_wr_reported(anchor: &SworkerAnchor, bn: BlockNumber) -> bool;
+	// Decrease the used value in anchor's work report
+	fn decrease_used(anchor: &SworkerAnchor, used: u64);
+    // Check whether the who and anchor is consistent with current status
+	fn check_anchor(who: &AccountId, anchor: &SworkerAnchor) -> bool;
+	// Get total used and free space
+	fn get_free_plus_used() -> u128;
+}
+
+/// Means for interacting with a specialized version of the `market` trait.
+pub trait MarketInterface<AccountId> {
+	// used for `added_files`
+	// return is_added
+	fn upsert_replicas(who: &AccountId, cid: &MerkleRoot, anchor: &SworkerAnchor, valid_at: BlockNumber, members: &Option<BTreeSet<AccountId>>) -> bool;
+	// used for `delete_files`
+	// return is_deleted
+	fn delete_replicas(who: &AccountId, cid: &MerkleRoot, anchor: &SworkerAnchor, curr_bn: BlockNumber) -> bool;
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,6 +73,7 @@ sp-runtime-interface = { default-features = false, version = '2.0.0' }
 swork = { version = "0.10.0", package = 'cstrml-swork', path = '../cstrml/swork', default-features = false }
 staking = { version = "0.10.0", package = 'cstrml-staking', path = '../cstrml/staking', default-features = false }
 market = { version = "0.10.0", package = 'cstrml-market', path = '../cstrml/market', default-features = false }
+market_v2 = { version = "0.10.0", package = 'cstrml-market-v2', path = '../cstrml/market_v2', default-features = false }
 primitives = { version = "0.10.0", package = 'cst-primitives', path = '../primitives', default-features = false }
 balances = { version = "0.10.0", package = 'cstrml-balances', path = '../cstrml/balances', default-features = false }
 candy = { version = "0.10.0", package = 'cstrml-candy', path = '../cstrml/candy', default-features = false  }
@@ -127,6 +128,7 @@ std = [
     'swork/std',
     'staking/std',
     'market/std',
+    'market_v2/std',
     'primitives/std',
     'candy/std'
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -656,39 +656,48 @@ impl pallet_sudo::Trait for Runtime {
     type Call = Call;
 }
 
-parameter_types! {
-    pub const MaxBondsLimit: u32 = 10;
-}
-
 impl swork::Trait for Runtime {
     type Currency = Balances;
     type Event = Event;
     type Works = Staking;
     type MarketInterface = Market;
-    type MaxBondsLimit = MaxBondsLimit;
     type WeightInfo = swork::weight::WeightInfo;
 }
 
 parameter_types! {
     /// Unit is pico
-    pub const MinimumStoragePrice: Balance = 40;
-    /// Unit is minute
-    pub const MinimumSorderDuration: u32 = 30;
+    pub const MarketModuleId: ModuleId = ModuleId(*b"crmarket");
+    pub const FileDuration: BlockNumber = 15 * DAYS;
+    pub const InitialReplica: u32 = 4;
+    pub const FileBaseFee: Balance = CENTS / 20;  // roughly equal to 1RMB / month
+    pub const FileInitPrice: Balance = MILLICENTS / 10; // Need align with FileDuration and InitialReplica
     pub const ClaimLimit: u32 = 1000;
-    pub const Frequency: BlockNumber = 10 * MINUTES;
+    pub const StorageReferenceRatio: u128 = 4; // 1/4 = 25%
+    pub StorageIncreaseRatio: Perbill = Perbill::from_rational_approximation(1u64, 10000);
+    pub StorageDecreaseRatio: Perbill = Perbill::from_rational_approximation(5u64, 10000);
+    pub const StakingRatio: Perbill = Perbill::from_percent(80);
+    pub const UsedTrashMaxSize: u128 = 500_000;
 }
 
-impl market::Trait for Runtime {
+impl market_v2::Trait for Runtime {
+
+    /// The market's module id, used for deriving its sovereign account ID.
+    type ModuleId = MarketModuleId;
     type Currency = Balances;
     type CurrencyToBalance = CurrencyToVoteHandler;
+    type SworkerInterface = Swork;
     type Event = Event;
-    type Randomness = RandomnessCollectiveFlip;
-    // TODO: Bonding with balance module(now we impl inside Market)
-    type OrderInspector = Swork;
-    type MinimumStoragePrice = MinimumStoragePrice;
-    type MinimumSorderDuration = MinimumSorderDuration;
+    /// File duration.
+    type FileDuration = FileDuration;
+    type InitialReplica = InitialReplica;
+    type FileBaseFee = FileBaseFee;
+    type FileInitPrice = FileInitPrice;
     type ClaimLimit = ClaimLimit;
-    type WeightInfo = market::weight::WeightInfo;
+    type StorageReferenceRatio = StorageReferenceRatio;
+    type StorageDecreaseRatio = StorageDecreaseRatio;
+    type StorageIncreaseRatio = StorageIncreaseRatio;
+    type StakingRatio = StakingRatio;
+    type UsedTrashMaxSize = UsedTrashMaxSize;
 }
 
 construct_runtime! {
@@ -739,7 +748,7 @@ construct_runtime! {
 
         // Crust modules
         Swork: swork::{Module, Call, Storage, Event<T>, Config},
-        Market: market::{Module, Call, Storage, Event<T>},
+        Market: market_v2::{Module, Call, Storage, Event<T>},
 
         // Sudo. Last module. Usable initially, but removed once governance enabled.
         Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
@@ -973,7 +982,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, balances, Balances);
             add_benchmark!(params, batches, system, SystemBench::<Runtime>);
             add_benchmark!(params, batches, staking, Staking);
-            add_benchmark!(params, batches, market, Market);
+            // add_benchmark!(params, batches, market, Market);
             add_benchmark!(params, batches, swork, Swork);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }


### PR DESCRIPTION
# DSM 2.0

## Description

Biiiiiiggest pr since repo created ☄️

Resolved #286
Resolved #287 
Resolved #288
Resolved #289 
Resolved #290  
Resolved #291  

Here is the spec details

> New DSM2.0 change including MPoW，DSM and Payment modules，The key features including: **MPoW Group，DSM I, II class files，Payment pool，Payouts update**。

## Mechanism

### New MPoW (Change part)

#### 1. WorkReport

```rust
pub struct WorkReport {
  /// Timing judgement
  pub report_slot: u64,

  /// Real storage information
  pub used: u64, // Real file(mapping with dsm::Files) size
  pub free: u64, // Srd size

  /// Assist judgement
  pub reported_files_size: u64, // Reported files size
  pub reported_srd_root: MerkleRoot, // Srd hash root
  pub reported_files_root: MerkleRoot, // Reported files hash root
}
```

#### 2. Identities -> PubKeys

```rust
Map<SworkerPubKey, Option<PKInfo>> // is bonded?
```

```rust
struct PKInfo {
  code: SworkerCode,
  anchor: Anchor,
  is_bonded: bool, //Is bonded by some account
}
```

- `Anchor`is the anchor relationship with sworker pub key, will be used in `ReportInSlot` and `Files`
- Insert when report work
- Delete when chill

#### 3. Change IdBonds

Change to 1:1 bonding，a AccountId can only map to a Work Report

- **Data structure**

```rust
Map<AccountId, Identity<T>>
```

```rust
struct Identity<T> {
  a: Anchor,
  group: Option<T::AccountId>
}
```
  
- **Update algorithm logic**

  - Create bonding relationship when Report Works（A/B Upgrade/Relace old/New）;
  - Chill should change
  - Update group when join group

#### 4. New structure：IdGroup

Each account can create `Group`，and accept different Accounts

- **Data structure**

```rust
Map<AccountId, BTreeSet<AccountId>>
```

Main key is owne's AccountId，owner should also add into `BTreeSet<AccountId>`.

- **Algorithm logic**
  
  - *Join Group*：New/Join/Change Group，Condition is candidate should has **work report** and make it's used=0**；
  - *Exit Group*：Exist Group，owner cannot allow to exist group（Unless group only contains ownerself）；
  - Details：When change group，should query if it joint a group；

- **Group features**

  - Same Group member will account `stake limit` into  owner；
  - Memeber's `stake_limit` goes 0；

- **Details**
  - When a member joins the Group, it will automatically change used and free to 0, and add them to the owner; is this sentence gone?
  - When the member reports the workload, determine whether there is an owner, if so, count `used` and `free` on the owner, otherwise count as own;

#### 5. Change Report Works
  - For the processing of added_files: whether there is a file corresponding to DSM, if there is, count to used, and call the dsm::update_file function (add payouts list), if not, just ignore it
  - For the processing of deleted_files: whether there is a file corresponding to DSM, if there is, call dsm::update_file (to determine whether it belongs to the top of the payout list), if not, ignore it;

#### 6. Change update_identity

- Still loop all identities (judging all work reports), update the corresponding stake limit according to the `used` and `free` of the account; skip if there is an owner

### New DSM Mechanism

#### 1. Pots

Record the fund pool of the DSM order

- **Fund Pool Related**:

  - StakingPot: 2:8 to store orders, 80% will enter this pool for directional rewards to the staking module;
  - FilesPot: 2:8 store orders, 20% enter this pool, used to pay for the rewards of class I files
  - PledgePot: Merchant's margin pool
  - ReservedPot: The remaining order amount due to overdue/non-reported work report;

#### 2. Files structure

When the user places an order, enter the storage structure created after `cid`

- **Data Structure**:

```rust
Map<CID, FileInfo>
```

```rust
struct FileInfo {
  size: u64,
  expired_on: BlockNumber,
  claimed_at: BlockNumber, // The block height of the last reward
  amount: Balance, // Fund pool for recharge
  expected_payouts: u8, // expected payouts
  payouts: Vec<AccountId>, // All accounts that save this file, the array is ordered by default
}
```

```rust
DoubleMap<CID, AccountId, (Anchor, BlockNumber)> // The corresponding relationship between the stored file and the account must be stored in Anchor to determine whether it is a real report
```

-**Algorithm logic**:

  - Order: Create FileInfo, `expected_payout` is 4, `payouts` is empty, `expired_on` is the current bn, `claim_at` = `expired_on`; expired_on should be triggered by report_work
  - Renewal (normal): `expired_on` merge;
  - Extensions: `expected_payouts` increased by 2;
  - payouts: When claiming rewards, call `dsm::payout(account_id, duration_ratio, total)` to determine whether the deposit of each candidate and the work report are expired to determine whether to pay the candidate;
  - delete_file: Triggered when the work report deletes a file, and it is directly removed from the payouts list;
  - add_file: triggered when a file is added to the work report, and added to the payouts list;
  - Changes in payouts (addition or deletion) involve triggers: changes are different. Is money counting separated from changes? Return the expired result when counting money
    - Record the old `old_1st_volume = dsm::calculate_1st_ratio(cid)` before updating
    - Call `dsm::payout(account_id, duration_ratio, total)` to trigger payout and perform payment operations
    - Recalculate the rate of a type of file `new_1st_volume = dsm::calculate_1st_ratio(cid)` This should only be triggered when placing an order
    - Update `fst_file_volume`

#### 3. FileVolume

File size guaranteed by user funds = min(expected_payouts, (len(payouts) - invalid_payouts)) * size

- **Data Structure**：

```rust
u128
```

- **Algorithm Logic**：

`total = old_total - old_1st_volume + new_1st_volume`

#### 4. FilePrice

Uniform file prices across the entire network, and adjust them by referring to the ratio of FstFileVolume by placing orders by users

- **Data Structure**：

```rust
u128 // unit: pico
```

- **Algorithm logic**:
  - Adjust the price every time the user places an order `dsm::calculate_price()`
  - `fst_file_ratio(= fst_file_volume / total_volume)` greater than 50%, `*= 1.01`
  - `fst_file_ratio` less than 50%, `*= 0.99`

#### 5. Ledger

Record merchant's pending money

1. **Data Structure**：

```rust
Map<AccountId, Balance>// Merge claim and pledge
```


1. **Algorithm Logic**：Cover the whole operations of payout

- Report works(delete_files): Payout may be triggered when files are deleted;
- Recharge: Recharge the file to trigger the payout operation;
- Claim: Trigger the delete operation

#### 6. FileTrashI & FileTrashII


The second type of file pool is used to record the expired order files. When calculating the stake limit, it will be used to determine whether it is still a valid file. Trash will be cleaned up in time, when another Trash reaches a critical value

- **Data Structure**：

```rust
BTreeSet<CID>
```

- **Algorithm Logic**：

When the claim expires, it will trigger the addition of the second type of file pool: when joining, it will determine two recycle bins, and when one of them is the last to join, call `dsm::pour(another_trash_id)` to dump the other recycle bin.
