### PR TITLE
[MPoW] An account can be group owner without identity information right now

### DIFF
--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -235,7 +235,7 @@ decl_error! {
         /// Group already exist
         GroupAlreadyExist,
         /// Group owner cannot register
-        GroupOwnerCannotRegister
+        GroupOwnerForbidden
     }
 }
 
@@ -294,7 +294,7 @@ decl_module! {
             ensure!(&who == &applier, Error::<T>::IllegalApplier);
 
             // 2. Ensure who cannot be group owner
-            ensure!(!<Groups<T>>::contains_key(&who), Error::<T>::GroupOwnerCannotRegister);
+            ensure!(!<Groups<T>>::contains_key(&who), Error::<T>::GroupOwnerForbidden);
 
             // 3. Ensure unparsed_identity trusted chain is legal, including signature and sworker code
             let maybe_pk = Self::check_and_get_pk(&ias_sig, &ias_cert, &applier, &isv_body, &sig);
@@ -349,7 +349,7 @@ decl_module! {
             ensure!(PubKeys::contains_key(&curr_pk), Error::<T>::IllegalReporter);
 
             // 2. Ensure who cannot be group owner
-            ensure!(!<Groups<T>>::contains_key(&reporter), Error::<T>::GroupOwnerCannotRegister);
+            ensure!(!<Groups<T>>::contains_key(&reporter), Error::<T>::GroupOwnerForbidden);
             
             // 3. Ensure reporter's code is legal
             ensure!(Self::reporter_code_check(&curr_pk, slot), Error::<T>::OutdatedReporter);
@@ -491,7 +491,7 @@ decl_module! {
             let who = ensure_signed(origin)?;
 
             // 1. Ensure who didn't report work before
-            ensure!(Self::identities(&who).is_none(), Error::<T>::GroupOwnerCannotRegister);
+            ensure!(Self::identities(&who).is_none(), Error::<T>::GroupOwnerForbidden);
 
             // 2. Ensure who is not a group owner right now
             ensure!(!<Groups<T>>::contains_key(&who), Error::<T>::GroupAlreadyExist);

--- a/cstrml/swork/src/tests.rs
+++ b/cstrml/swork/src/tests.rs
@@ -1225,11 +1225,13 @@ fn create_and_join_group_should_work() {
 }
 
 #[test]
-fn double_create_group_should_fail() {
+fn create_group_should_fail_due_to_invalid_situations() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
             let alice = Sr25519Keyring::Alice.to_account_id();
+            let a_wr_info = legal_work_report();
+            let a_pk = a_wr_info.curr_pk.clone();
 
             // Alice create a group and be the owner
             assert_ok!(Swork::create_group(
@@ -1244,11 +1246,96 @@ fn double_create_group_should_fail() {
                 error: 14,
                 message: Some("GroupAlreadyExist"),
             });
+
+            register_identity(&alice, &a_pk, &a_pk);
+
+            assert_noop!(Swork::create_group(
+                Origin::signed(alice.clone())
+            ),
+            DispatchError::Module {
+                index: 0,
+                error: 15,
+                message: Some("GroupOwnerCannotRegister"),
+            });
         });
 }
 
 #[test]
-fn join_group_should_failed_due_to_invalid_situations() {
+fn register_should_fail_due_to_reporter_is_group_owner() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(|| {
+            let applier: AccountId =
+                AccountId::from_ss58check("5FqazaU79hjpEMiWTWZx81VjsYFst15eBuSBKdQLgQibD7CX")
+                    .expect("valid ss58 address");
+            let register_info = legal_register_info();
+
+            // Alice create a group and be the owner
+            assert_ok!(Swork::create_group(
+                Origin::signed(applier.clone())
+            ));
+
+            assert_noop!(
+                Swork::register(
+                    Origin::signed(applier.clone()),
+                    register_info.ias_sig,
+                    register_info.ias_cert,
+                    register_info.account_id,
+                    register_info.isv_body,
+                    register_info.sig
+                ),
+                DispatchError::Module {
+                    index: 0,
+                    error: 15,
+                    message: Some("GroupOwnerCannotRegister"),
+                }
+            );
+        });
+}
+
+#[test]
+fn report_works_should_fail_due_to_reporter_is_group_owner() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(|| {
+            // Generate 303 blocks first
+            run_to_block(303);
+
+            let reporter: AccountId = Sr25519Keyring::Alice.to_account_id();
+            let legal_wr_info = legal_work_report_with_added_files();
+            let legal_pk = legal_wr_info.curr_pk.clone();
+
+            register(&legal_pk, LegalCode::get());
+            add_not_live_files();
+            // Alice create a group and be the owner
+            assert_ok!(Swork::create_group(
+                Origin::signed(reporter.clone())
+            ));
+            assert_noop!(
+                Swork::report_works(
+                    Origin::signed(reporter.clone()),
+                    legal_wr_info.curr_pk,
+                    legal_wr_info.prev_pk,
+                    legal_wr_info.block_number,
+                    legal_wr_info.block_hash,
+                    legal_wr_info.free,
+                    legal_wr_info.used,
+                    legal_wr_info.added_files,
+                    legal_wr_info.deleted_files,
+                    legal_wr_info.srd_root,
+                    legal_wr_info.files_root,
+                    legal_wr_info.sig
+                ),
+                DispatchError::Module {
+                    index: 0,
+                    error: 15,
+                    message: Some("GroupOwnerCannotRegister"),
+                });
+        });
+}
+
+#[test]
+fn join_group_should_fail_due_to_invalid_situations() {
     ExtBuilder::default()
         .build()
         .execute_with(|| {
@@ -1348,6 +1435,7 @@ fn join_group_should_work_for_used_in_work_report() {
             let alice = Sr25519Keyring::Alice.to_account_id();
             let bob = Sr25519Keyring::Bob.to_account_id();
             let eve = Sr25519Keyring::Eve.to_account_id();
+            let ferdie = Sr25519Keyring::Ferdie.to_account_id();
 
             // Get work report in 300 slot fo alice, bob and eve
             let alice_wr_info = group_work_report_alice_300();
@@ -1371,22 +1459,24 @@ fn join_group_should_work_for_used_in_work_report() {
             let file_d = hex::decode("66a706320afc633bfb843108e492192b17d2b6b9d9ee0b795ee95417fe08b110").unwrap(); // D file
             let file_e = hex::decode("33cdb315c8c37e2dc00fa2a8c7fe51b8149b363d29f404441982f96d2bbae12e").unwrap(); // E file
 
+            // alice, bob and eve become a group
             assert_ok!(Swork::create_group(
-                Origin::signed(alice.clone())
+                Origin::signed(ferdie.clone())
             ));
 
-            // alice, bob and eve become a group
             assert_ok!(Swork::join_group(
                 Origin::signed(alice.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
+
             assert_ok!(Swork::join_group(
                 Origin::signed(bob.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
+
             assert_ok!(Swork::join_group(
                 Origin::signed(eve.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
 
             run_to_block(303);
@@ -1943,6 +2033,7 @@ fn join_group_should_work_for_stake_limit() {
             let alice = Sr25519Keyring::Alice.to_account_id();
             let bob = Sr25519Keyring::Bob.to_account_id();
             let eve = Sr25519Keyring::Eve.to_account_id();
+            let ferdie = Sr25519Keyring::Ferdie.to_account_id();
 
             let alice_wr_info = group_work_report_alice_300();
             let bob_wr_info = group_work_report_bob_300();
@@ -1958,39 +2049,25 @@ fn join_group_should_work_for_stake_limit() {
             register_identity(&bob, &b_pk, &b_pk);
             register_identity(&eve, &c_pk, &c_pk);
 
+            // alice, bob and eve become a group
             assert_ok!(Swork::create_group(
-                Origin::signed(alice.clone())
+                Origin::signed(ferdie.clone())
             ));
 
             assert_ok!(Swork::join_group(
                 Origin::signed(alice.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
-
-            assert_eq!(Swork::identities(&alice).unwrap_or_default(), Identity {
-                anchor: a_pk.clone(),
-                group: Some(alice.clone())
-            });
 
             assert_ok!(Swork::join_group(
                 Origin::signed(bob.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
-
-            assert_eq!(Swork::identities(&bob).unwrap_or_default(), Identity {
-                anchor: b_pk.clone(),
-                group: Some(alice.clone())
-            });
 
             assert_ok!(Swork::join_group(
                 Origin::signed(eve.clone()),
-                alice.clone()
+                ferdie.clone()
             ));
-
-            assert_eq!(Swork::identities(&eve).unwrap_or_default(), Identity {
-                anchor: c_pk.clone(),
-                group: Some(alice.clone())
-            });
 
             run_to_block(303);
             Swork::update_identities();
@@ -2049,7 +2126,8 @@ fn join_group_should_work_for_stake_limit() {
             assert_eq!(Swork::current_report_slot(), 600);
             let map = WorkloadMap::get().borrow().clone();
             // All workload is counted to alice. bob and eve is None.
-            assert_eq!(*map.get(&alice).unwrap(), 12884902022u128);
+            assert_eq!(*map.get(&ferdie).unwrap(), 12884902022u128);
+            assert_eq!(map.get(&alice).is_none(), true);
             assert_eq!(map.get(&bob).is_none(), true);
             assert_eq!(map.get(&eve).is_none(), true);
         });

--- a/cstrml/swork/src/tests.rs
+++ b/cstrml/swork/src/tests.rs
@@ -1255,7 +1255,7 @@ fn create_group_should_fail_due_to_invalid_situations() {
             DispatchError::Module {
                 index: 0,
                 error: 15,
-                message: Some("GroupOwnerCannotRegister"),
+                message: Some("GroupOwnerForbidden"),
             });
         });
 }
@@ -1287,7 +1287,7 @@ fn register_should_fail_due_to_reporter_is_group_owner() {
                 DispatchError::Module {
                     index: 0,
                     error: 15,
-                    message: Some("GroupOwnerCannotRegister"),
+                    message: Some("GroupOwnerForbidden"),
                 }
             );
         });
@@ -1329,7 +1329,7 @@ fn report_works_should_fail_due_to_reporter_is_group_owner() {
                 DispatchError::Module {
                     index: 0,
                     error: 15,
-                    message: Some("GroupOwnerCannotRegister"),
+                    message: Some("GroupOwnerForbidden"),
                 });
         });
 }


### PR DESCRIPTION
Fix #355. An account can be group owner without reporting work.