### PR TITLE
Maxwell 23 (#600)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crust"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "crust-rpc",
  "crust-runtime",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "crust-rpc"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "crust-runtime",
  "cst-primitives",
@@ -1131,12 +1131,13 @@ dependencies = [
 
 [[package]]
 name = "crust-runtime"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cst-primitives",
  "cstrml-balances",
  "cstrml-candy",
  "cstrml-claims",
+ "cstrml-csm-locking",
  "cstrml-market",
  "cstrml-staking",
  "cstrml-swork",
@@ -1225,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "cst-primitives"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1237,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-balances"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cst-primitives",
  "frame-benchmarking",
@@ -1254,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-candy"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1268,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-claims"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cstrml-balances",
  "frame-support",
@@ -1285,8 +1286,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstrml-csm-locking"
+version = "0.12.0"
+dependencies = [
+ "cst-primitives",
+ "cstrml-balances",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "safe-mix",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-keyring",
+ "sp-runtime",
+ "sp-std",
+ "substrate-test-utils",
+]
+
+[[package]]
 name = "cstrml-market"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cst-primitives",
  "cstrml-balances",
@@ -1306,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-staking"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cst-primitives",
  "cstrml-balances",
@@ -1332,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-swork"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "base64 0.12.3",
  "cst-primitives",
@@ -1355,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "cstrml-swork-benchmarking"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cst-primitives",
  "cstrml-balances",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     'cstrml/staking',
     'cstrml/swork',
     'cstrml/market',
+    'cstrml/csm-locking',
     'cstrml/swork/benchmarking',
     'runtime',
     'rpc',

--- a/cstrml/candy/Cargo.toml
+++ b/cstrml/candy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-candy"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/claims/Cargo.toml
+++ b/cstrml/claims/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-claims"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/csm-locking/Cargo.toml
+++ b/cstrml/csm-locking/Cargo.toml
@@ -1,42 +1,56 @@
 [package]
-name = "cstrml-balances"
+name = "cstrml-csm-locking"
 version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
-license = "GPL-3.0"
+license = "Apache-2.0"
 homepage = "https://crust.network"
 repository = "https://github.com/crustio/crust/"
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [dependencies]
+# third party dependencies
 serde = { optional = true, version = "1.0.116" }
+safe-mix = { default-features = false, version = "1.0.0" }
 codec = { package = "parity-scale-codec", default-features = false, features = ["derive"], version = "2.0.0" }
-sp-std = { default-features = false, version = "3.0.0" }
-sp-runtime = { default-features = false, version = "3.0.0" }
-frame-benchmarking = { default-features = false, optional = true, version = "3.0.0" }
+
+# substrate frame dependencies
 frame-support = { default-features = false, version = "3.0.0" }
 frame-system = { default-features = false, version = "3.0.0" }
+
+# substrate primitives
+sp-keyring = { optional = true, version = "3.0.0" }
+sp-std = { default-features = false, version = "3.0.0" }
+sp-io ={ default-features = false, version = "3.0.0" }
+sp-runtime = { default-features = false, version = "3.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "3.0.0" }
 
 # crust runtime modules
 primitives = { package = "cst-primitives", path = "../../primitives", default-features = false }
 
 [dev-dependencies]
-sp-io = "3.0.0"
 sp-core = "3.0.0"
-pallet-transaction-payment = "3.0.0"
+balances = { package = "cstrml-balances", path = "../balances" }
+pallet-timestamp = "3.0.0"
+frame-benchmarking = "3.0.0"
+
+# private crate inside substrate
+substrate-test-utils = "3.0.0"
 
 [features]
-default = ["std"]
+equalize = []
+migrate = []
+default = ["std", "equalize"]
 std = [
 	"serde",
+	"safe-mix/std",
+	"sp-keyring",
 	"codec/std",
 	"sp-std/std",
-	"sp-runtime/std",
-	"frame-benchmarking/std",
+	"sp-io/std",
 	"frame-support/std",
+	"sp-runtime/std",
 	"frame-system/std",
-	"primitives/std"
 ]
-runtime-benchmarks = ["frame-benchmarking"]
+runtime-benchmarks = [
+    "frame-benchmarking",
+]

--- a/cstrml/csm-locking/src/lib.rs
+++ b/cstrml/csm-locking/src/lib.rs
@@ -1,0 +1,336 @@
+// Copyright (C) 2019-2021 Crust Network Technologies Ltd.
+// This file is part of Crust.
+
+#![recursion_limit = "128"]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+
+// #[cfg(any(feature = "runtime-benchmarks", test))]
+// pub mod benchmarking;
+
+#[cfg(test)]
+mod tests;
+
+use codec::{Decode, Encode, HasCompact};
+use frame_support::{
+    decl_module, decl_event, decl_storage, ensure, decl_error,
+    weights::{Weight, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
+    traits::{
+        Currency, LockIdentifier, LockableCurrency, WithdrawReasons, Get
+    },
+    dispatch::{DispatchResultWithPostInfo}
+};
+use sp_runtime::{
+    RuntimeDebug,
+    traits::{
+        Zero, Saturating, CheckedSub, AtLeast32BitUnsigned
+    },
+};
+
+use sp_std::{convert::TryInto, prelude::*};
+
+use frame_system::{ensure_root, ensure_signed};
+use primitives::BlockNumber;
+
+pub mod weight;
+
+const MAX_UNLOCKING_CHUNKS: usize = 32;
+const LOCKING_ID: LockIdentifier = *b"csm-lock";
+
+// TODO: Add benchmarking
+pub trait WeightInfo {
+    fn bond() -> Weight;
+    fn unbond() -> Weight;
+    fn rebond(l: u32, ) -> Weight;
+    fn withdraw_unbonded() -> Weight;
+}
+
+/// Just a Balance/BlockNumber tuple to encode when a chunk of funds will be unlocked.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, Default)]
+pub struct CSMUnlockChunk<Balance: HasCompact> {
+    /// Amount of funds to be unlocked.
+    #[codec(compact)]
+    value: Balance,
+    /// Block number at which point it'll be unlocked.
+    #[codec(compact)]
+    bn: BlockNumber,
+}
+
+/// The ledger of a account.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, Default)]
+pub struct CSMLedger<Balance: HasCompact> {
+    /// The total amount of the stash's balance that we are currently accounting for.
+    /// It's just `active` plus all the `unlocking` balances.
+    #[codec(compact)]
+    pub total: Balance,
+    /// The total amount of the stash's balance that will be at stake in any forthcoming
+    /// rounds.
+    #[codec(compact)]
+    pub active: Balance,
+    /// Any balance that is becoming free, which may eventually be transferred out
+    /// of the stash (assuming it doesn't get slashed first).
+    pub unlocking: Vec<CSMUnlockChunk<Balance>>,
+}
+
+impl<Balance: HasCompact + Copy + Saturating + AtLeast32BitUnsigned> CSMLedger<Balance> {
+    /// Remove entries from `unlocking` that are sufficiently old and reduce the
+    /// total by the sum of their balances.
+    fn consolidate_unlocked(self, curr_bn: BlockNumber) -> Self {
+        let mut total = self.total;
+        let unlocking = self
+            .unlocking
+            .into_iter()
+            .filter(|chunk| {
+                if chunk.bn > curr_bn {
+                    true
+                } else {
+                    total = total.saturating_sub(chunk.value);
+                    false
+                }
+            })
+            .collect();
+        Self {
+            total,
+            active: self.active,
+            unlocking
+        }
+    }
+
+    /// Re-bond funds that were scheduled for unlocking.
+    fn rebond(mut self, value: Balance) -> Self {
+        let mut unlocking_balance: Balance = Zero::zero();
+
+        while let Some(last) = self.unlocking.last_mut() {
+            if unlocking_balance + last.value <= value {
+                unlocking_balance += last.value;
+                self.active += last.value;
+                self.unlocking.pop();
+            } else {
+                let diff = value - unlocking_balance;
+
+                unlocking_balance += diff;
+                self.active += diff;
+                last.value -= diff;
+            }
+
+            if unlocking_balance >= value {
+                break
+            }
+        }
+
+        self
+    }
+}
+
+pub type BalanceOf<T> =
+    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+pub trait Config: frame_system::Config {
+    /// The locking balance.
+    type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
+
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+
+    /// Number of eras that staked funds must remain bonded for.
+    type BondingDuration: Get<BlockNumber>;
+
+    /// Weight information for extrinsics in this pallet.
+    type WeightInfo: WeightInfo;
+}
+
+decl_storage! {
+    trait Store for Module<T: Config> as CSMLocking {
+        /// Map from all (unlocked) "controller" accounts to the info regarding the CSM.
+        pub Ledger get(fn ledger):
+            map hasher(blake2_128_concat) T::AccountId
+            => CSMLedger<BalanceOf<T>>;
+    }
+}
+
+decl_event!(
+    pub enum Event<T> where
+        Balance = BalanceOf<T>,
+        <T as frame_system::Config>::AccountId
+    {
+        /// An account has bonded this amount. [stash, amount]
+        Bonded(AccountId, Balance),
+        /// An account has unbonded this amount. [stash, amount]
+        Unbonded(AccountId, Balance),
+        /// An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`
+        /// from the unlocking queue. [stash, amount]
+        Withdrawn(AccountId, Balance),
+    }
+);
+
+decl_error! {
+    /// Error for the locking module.
+    pub enum Error for Module<T: Config> {
+        /// Not bonded.
+        NotBonded,
+        /// Can not schedule more unlock chunks.
+        NoMoreChunks,
+        /// Can not bond with value less than minimum balance.
+        InsufficientValue,
+        /// Can not rebond without unlocking chunks.
+        NoUnlockChunk,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
+        /// Number of block number that locked funds must remain bonded for.
+        const BondingDuration: BlockNumber = T::BondingDuration::get();
+
+        type Error = Error<T>;
+
+        fn deposit_event() = default;
+
+        /// Lock some amount that have appeared in the account `free_balance` into the ledger
+        #[weight = T::WeightInfo::bond()]
+        fn bond(origin, #[compact] value: BalanceOf<T>) {
+            let who = ensure_signed(origin)?;
+
+            let mut ledger = Self::ledger(&who);
+
+            let free_balance = T::Currency::free_balance(&who);
+            if let Some(extra) = free_balance.checked_sub(&ledger.total) {
+                let extra = extra.min(value);
+                ledger.total += extra;
+                ledger.active += extra;
+                Self::update_ledger(&who, &ledger);
+                Self::deposit_event(RawEvent::Bonded(who, extra));
+            }
+        }
+
+        /// Schedule a portion of the account to be unlocked ready for transfer out after the bond
+        /// period ends. If this leaves an amount actively bonded less than
+        /// T::Currency::minimum_balance(), then it is increased to the full amount.
+        #[weight = T::WeightInfo::unbond()]
+        fn unbond(origin, #[compact] value: BalanceOf<T>) {
+            let who = ensure_signed(origin)?;
+
+            // 1. Ensure who has the ledger
+            ensure!(<Ledger<T>>::contains_key(&who), Error::<T>::NotBonded);
+            let mut ledger = Self::ledger(&who);
+
+            // 2. Judge if exceed MAX_UNLOCKING_CHUNKS
+            ensure!(
+                ledger.unlocking.len() < MAX_UNLOCKING_CHUNKS,
+                Error::<T>::NoMoreChunks,
+            );
+
+            // 3. Ensure value < ledger.active
+            let mut value = value;
+            value = value.min(ledger.active);
+            if !value.is_zero() {
+                ledger.active -= value;
+
+                // 4. Avoid there being a dust balance left in the csm locking system.
+                if ledger.active < T::Currency::minimum_balance() {
+                    value += ledger.active;
+                    ledger.active = Zero::zero();
+                }
+
+                // 5. Update ledger
+                let bn = Self::get_current_block_number() + T::BondingDuration::get();
+                ledger.unlocking.push(CSMUnlockChunk { value, bn });
+                Self::update_ledger(&who, &ledger);
+                Self::deposit_event(RawEvent::Unbonded(who, value));
+            }
+        }
+
+        /// Rebond a portion of the account scheduled to be unlocked.
+        #[weight = T::WeightInfo::rebond(MAX_UNLOCKING_CHUNKS as u32)]
+        fn rebond(origin, #[compact] value: BalanceOf<T>) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            // 1. Ensure who has the ledger
+            ensure!(<Ledger<T>>::contains_key(&who), Error::<T>::NotBonded);
+            let mut ledger = Self::ledger(&who);
+            ensure!(!ledger.unlocking.is_empty(), Error::<T>::NoUnlockChunk);
+
+            ledger = ledger.rebond(value);
+            // last check: the new active amount of ledger must be more than ED.
+            ensure!(ledger.active >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
+            Self::update_ledger(&who, &ledger);
+            Ok(Some(
+                35 * WEIGHT_PER_MICROS
+                + 50 * WEIGHT_PER_NANOS * (ledger.unlocking.len() as Weight)
+                + T::DbWeight::get().reads_writes(3, 2)
+            ).into())
+        }
+
+        /// Remove any unlocked chunks from the `unlocking` queue from our management.
+        ///
+        /// This essentially frees up that balance to be used by the stash account to do
+        /// whatever it wants.
+        ///
+        /// Emits `Withdrawn`.
+        #[weight = T::WeightInfo::withdraw_unbonded()]
+        fn withdraw_unbonded(origin) {
+            let who = ensure_signed(origin)?;
+            ensure!(<Ledger<T>>::contains_key(&who), Error::<T>::NotBonded);
+            let mut ledger = Self::ledger(&who);
+            let old_total = ledger.total;
+            let curr_bn = Self::get_current_block_number();
+            ledger = ledger.consolidate_unlocked(curr_bn);
+
+            if ledger.unlocking.is_empty() && ledger.active.is_zero() {
+                Self::kill_ledger(&who);
+            } else {
+                // This was the consequence of a partial unbond. just update the ledger and move on.
+                Self::update_ledger(&who, &ledger);
+            }
+
+            // `old_total` should never be less than the new total because
+            // `consolidate_unlocked` strictly subtracts balance.
+            if ledger.total < old_total {
+                // Already checked that this won't overflow by entry condition.
+                let value = old_total - ledger.total;
+                Self::deposit_event(RawEvent::Withdrawn(who, value));
+            }
+        }
+
+        /// Force a current account to become completely unstaked, immediately.
+        ///
+        /// The dispatch origin must be Root.
+        #[weight = T::DbWeight::get().reads_writes(4, 7)
+            .saturating_add(53 * WEIGHT_PER_MICROS)]
+        fn force_unstake(origin, who: T::AccountId) {
+            ensure_root(origin)?;
+            Self::kill_ledger(&who);
+        }
+    }
+}
+
+impl<T: Config> Module<T> {
+    fn get_current_block_number() -> BlockNumber {
+        let current_block_number = <frame_system::Module<T>>::block_number();
+        TryInto::<u32>::try_into(current_block_number).ok().unwrap()
+    }
+
+    /// Update the ledger for a controller. This will also update the stash lock. The lock will
+    /// will lock the entire funds except paying for further transactions.
+    fn update_ledger(
+        who: &T::AccountId,
+        ledger: &CSMLedger<BalanceOf<T>>,
+    ) {
+        T::Currency::set_lock(
+            LOCKING_ID,
+            who,
+            ledger.total,
+            WithdrawReasons::all(),
+        );
+        <Ledger<T>>::insert(who, ledger);
+    }
+
+    fn kill_ledger(who: &T::AccountId) {
+        // remove all locking-related information.
+        <Ledger<T>>::remove(who);
+        // remove the lock.
+        T::Currency::remove_lock(LOCKING_ID, who);
+    }
+}

--- a/cstrml/csm-locking/src/mock.rs
+++ b/cstrml/csm-locking/src/mock.rs
@@ -1,0 +1,176 @@
+// Copyright (C) 2019-2021 Crust Network Technologies Ltd.
+// This file is part of Crust.
+
+//! Test utilities
+
+use crate::*;
+use crate as csm_locking;
+use frame_support::{
+    parameter_types,
+    traits::{Get, OnInitialize, OnFinalize},
+    weights::constants::RocksDbWeight,
+};
+use sp_core::H256;
+use sp_runtime::testing::Header;
+use sp_runtime::traits::IdentityLookup;
+use std::cell::RefCell;
+use balances::AccountData;
+use frame_support::traits::StorageMapShim;
+
+/// The AccountId alias in this test module.
+pub type AccountId = u128;
+pub type BlockNumber = u64;
+pub type Balance = u64;
+
+thread_local! {
+    static EXISTENTIAL_DEPOSIT: RefCell<u64> = RefCell::new(0);
+}
+
+pub struct ExistentialDeposit;
+impl Get<u64> for ExistentialDeposit {
+    fn get() -> u64 {
+        EXISTENTIAL_DEPOSIT.with(|v| *v.borrow())
+    }
+}
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Test {
+    type BaseCallFilter = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Hash = H256;
+    type Hashing = ::sp_runtime::traits::BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = RocksDbWeight;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type SS58Prefix = ();
+}
+
+impl balances::Config for Test {
+    type Balance = Balance;
+    type DustRemoval = ();
+    type Event = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = StorageMapShim<
+        balances::Account<Test>,
+        frame_system::Provider<Test>,
+        AccountId,
+        balances::AccountData<Balance>,
+    >;
+    type WeightInfo = ();
+    type MaxLocks = ();
+}
+
+parameter_types! {
+    pub const BondingDuration: u32 = 1200;
+}
+
+impl Config for Test {
+    type Currency = Balances;
+    type Event = ();
+    type BondingDuration = BondingDuration;
+    type WeightInfo = weight::WeightInfo;
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
+		CSMLocking: csm_locking::{Module, Call, Storage, Event<T>},
+	}
+);
+
+pub struct ExtBuilder {
+    existential_deposit: u64,
+}
+
+impl Default for ExtBuilder {
+    fn default() -> Self {
+        Self {
+            existential_deposit: 1,
+        }
+    }
+}
+
+impl ExtBuilder {
+    pub fn set_associated_consts(&self) {
+        EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+    }
+    pub fn build(self) -> sp_io::TestExternalities {
+        self.set_associated_consts();
+        let mut storage = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap();
+        let balance_factor = if self.existential_deposit > 1 { 256 } else { 1 };
+
+        let _ = balances::GenesisConfig::<Test> {
+            balances: vec![
+                (1, 10 * balance_factor),
+                (2, 20 * balance_factor),
+                (3, 300 * balance_factor),
+                (4, 400 * balance_factor),
+                (10, balance_factor),
+                (11, balance_factor * 1000),
+                (20, balance_factor),
+                (21, balance_factor * 2000),
+                (30, balance_factor),
+                (31, balance_factor * 2000),
+                (40, balance_factor),
+                (41, balance_factor * 2000),
+                (50, balance_factor),
+                (51, balance_factor * 1000),
+                (60, balance_factor),
+                (61, balance_factor * 2000),
+                (70, balance_factor),
+                (71, balance_factor * 2000),
+                (80, balance_factor),
+                (81, balance_factor * 2000),
+                (100, 2000 * balance_factor),
+                (101, 2000 * balance_factor),
+                // This allow us to have a total_payout different from 0.
+                (999, 1_000_000_000_000)
+            ],
+        }.assimilate_storage(&mut storage);
+
+        let ext = sp_io::TestExternalities::from(storage);
+        ext
+    }
+}
+
+/// Run until a particular block.
+pub fn run_to_block(n: u64) {
+    // This block hash is for the valid work report
+    // let bh = maybe_bh.unwrap_or(hex::decode("05404b690b0c785bf180b2dd82a431d88d29baf31346c53dbda95e83e34c8a75").unwrap());
+    // let fake_bh = H256::from_slice(bh.as_slice());
+    while System::block_number() < n {
+        // <system::BlockHash<Test>>::insert(System::block_number(), fake_bh.clone());
+        if System::block_number() > 1 {
+            System::on_finalize(System::block_number());
+        }
+        System::on_initialize(System::block_number());
+        System::set_block_number(System::block_number() + 1);
+    }
+}

--- a/cstrml/csm-locking/src/tests.rs
+++ b/cstrml/csm-locking/src/tests.rs
@@ -1,0 +1,323 @@
+// Copyright (C) 2019-2021 Crust Network Technologies Ltd.
+// This file is part of Crust.
+
+//! Tests for the module.
+use super::*;
+use crate::mock::*;
+use frame_support::{
+    assert_noop, assert_ok,
+    traits::{Currency},
+};
+use crate::CSMUnlockChunk;
+
+#[test]
+fn bond_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let _ = Balances::make_free_balance_be(&11, 1500);
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 1000,
+                unlocking: vec![]
+            }
+        );
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 200));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1200,
+                active: 1200,
+                unlocking: vec![]
+            }
+        );
+
+        let _ = Balances::make_free_balance_be(&11, 3000);
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1800));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 3000,
+                active: 3000,
+                unlocking: vec![]
+            }
+        );
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 3000,
+                active: 3000,
+                unlocking: vec![]
+            }
+        );
+    });
+}
+
+#[test]
+fn unbond_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let _ = Balances::make_free_balance_be(&11, 1500);
+        assert_noop!(
+            CSMLocking::unbond(Origin::signed(11), 500),
+            Error::<Test>::NotBonded,
+        );
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 1000,
+                unlocking: vec![]
+            }
+        );
+        run_to_block(300);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 200));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 800,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 200,
+                        bn: 1500
+                    }
+                ]
+            }
+        );
+
+        let _ = Balances::make_free_balance_be(&11, 3000);
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1800));
+        // There is no limits
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 2600,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 200,
+                        bn: 1500
+                    }
+                ]
+            }
+        );
+
+        run_to_block(700);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 400));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 2200,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 200,
+                        bn: 1500
+                    },
+                    CSMUnlockChunk {
+                        value: 400,
+                        bn: 1900
+                    }
+                ]
+            }
+        );
+
+        for _ in 0..30 {
+            assert_ok!(CSMLocking::unbond(Origin::signed(11), 1));
+        }
+        assert_noop!(
+            CSMLocking::unbond(Origin::signed(11), 500),
+            Error::<Test>::NoMoreChunks,
+        );
+    });
+}
+
+#[test]
+fn rebond_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let _ = Balances::make_free_balance_be(&11, 3000);
+        assert_noop!(
+            CSMLocking::rebond(Origin::signed(11), 500),
+            Error::<Test>::NotBonded,
+        );
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 1000,
+                unlocking: vec![]
+            }
+        );
+        run_to_block(300);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 200));
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1800));
+        run_to_block(700);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 400));
+
+        run_to_block(1000);
+        assert_ok!(CSMLocking::rebond(Origin::signed(11), 300));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 2500,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 200,
+                        bn: 1500
+                    },
+                    CSMUnlockChunk {
+                        value: 100,
+                        bn: 1900
+                    }
+                ]
+            }
+        );
+        run_to_block(2000);
+        assert_ok!(CSMLocking::rebond(Origin::signed(11), 200));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 2700,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 100,
+                        bn: 1500
+                    },
+                ]
+            }
+        );
+        run_to_block(3000);
+        assert_ok!(CSMLocking::rebond(Origin::signed(11), 2000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 2800,
+                unlocking: vec![]
+            }
+        );
+
+        assert_noop!(
+            CSMLocking::rebond(Origin::signed(11), 500),
+            Error::<Test>::NoUnlockChunk,
+        );
+    });
+}
+
+
+#[test]
+fn withdraw_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let _ = Balances::make_free_balance_be(&11, 3000);
+        assert_noop!(
+            CSMLocking::withdraw_unbonded(Origin::signed(11)),
+            Error::<Test>::NotBonded,
+        );
+
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 1000,
+                unlocking: vec![]
+            }
+        );
+        run_to_block(300);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 200));
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1800));
+        run_to_block(700);
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 400));
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 400));
+
+        run_to_block(1000);
+        assert_ok!(CSMLocking::withdraw_unbonded(Origin::signed(11)));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2800,
+                active: 1800,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 200,
+                        bn: 1500
+                    },
+                    CSMUnlockChunk {
+                        value: 400,
+                        bn: 1900
+                    },
+                    CSMUnlockChunk {
+                        value: 400,
+                        bn: 1900
+                    }
+                ]
+            }
+        );
+
+        run_to_block(1550);
+        assert_ok!(CSMLocking::withdraw_unbonded(Origin::signed(11)));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 2600,
+                active: 1800,
+                unlocking: vec![
+                    CSMUnlockChunk {
+                        value: 400,
+                        bn: 1900
+                    },
+                    CSMUnlockChunk {
+                        value: 400,
+                        bn: 1900
+                    }
+                ]
+            }
+        );
+
+        run_to_block(2000);
+        assert_ok!(CSMLocking::withdraw_unbonded(Origin::signed(11)));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1800,
+                active: 1800,
+                unlocking: vec![]
+            }
+        );
+        assert_ok!(CSMLocking::unbond(Origin::signed(11), 2200));
+        run_to_block(3300);
+        assert_ok!(CSMLocking::withdraw_unbonded(Origin::signed(11)));
+        assert_eq!(<Ledger<Test>>::contains_key(&11), false);
+        assert_eq!(Balances::locks(&1).len(), 0);
+    });
+}
+
+#[test]
+fn force_unstake_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let _ = Balances::make_free_balance_be(&11, 3000);
+        assert_ok!(CSMLocking::bond(Origin::signed(11), 1000));
+        assert_eq!(
+            CSMLocking::ledger(&11),
+            CSMLedger {
+                total: 1000,
+                active: 1000,
+                unlocking: vec![]
+            }
+        );
+        assert_ok!(CSMLocking::force_unstake(Origin::root(), 11));
+        assert_eq!(<Ledger<Test>>::contains_key(&11), false);
+        assert_eq!(Balances::locks(&1).len(), 0);
+    });
+}

--- a/cstrml/csm-locking/src/weight.rs
+++ b/cstrml/csm-locking/src/weight.rs
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2021 Crust Network Technologies Ltd.
+// This file is part of Crust.
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl crate::WeightInfo for WeightInfo {
+	fn bond() -> Weight {
+		(67_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(10 as Weight))
+			.saturating_add(DbWeight::get().writes(7 as Weight))
+	}
+	fn unbond() -> Weight {
+		(52_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(8 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
+	}
+	fn rebond(l: u32, ) -> Weight {
+		(37_039_000 as Weight)
+			// Standard Error: 2_000
+			.saturating_add((93_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+	fn withdraw_unbonded() -> Weight {
+		(34_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+}

--- a/cstrml/market/Cargo.toml
+++ b/cstrml/market/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-market"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -149,13 +149,12 @@ parameter_types! {
     pub const MarketModuleId: ModuleId = ModuleId(*b"crmarket");
     pub const FileDuration: BlockNumber = 1000;
     pub const FileReplica: u32 = 4;
-    pub const FileBaseFee: Balance = 1000;
     pub const FileInitPrice: Balance = 1000; // Need align with FileDuration and FileBaseReplica
     pub const StorageReferenceRatio: (u128, u128) = (1, 2);
     pub const StorageIncreaseRatio: Perbill = Perbill::from_percent(1);
     pub const StorageDecreaseRatio: Perbill = Perbill::from_percent(1);
-    pub const StakingRatio: Perbill = Perbill::from_percent(80);
-    pub const TaxRatio: Perbill = Perbill::from_percent(10);
+    pub const StakingRatio: Perbill = Perbill::from_percent(72);
+    pub const StorageRatio: Perbill = Perbill::from_percent(18);
     pub const UsedTrashMaxSize: u128 = 2;
     pub const MaximumFileSize: u64 = 137_438_953_472; // 128G = 128 * 1024 * 1024 * 1024
     pub const RenewRewardRatio: Perbill = Perbill::from_percent(5);
@@ -169,14 +168,13 @@ impl Config for Test {
     type Event = ();
     type FileDuration = FileDuration;
     type FileReplica = FileReplica;
-    type FileBaseFee = FileBaseFee;
     type FileInitPrice = FileInitPrice;
     type StorageReferenceRatio = StorageReferenceRatio;
     type StorageIncreaseRatio = StorageIncreaseRatio;
     type StorageDecreaseRatio = StorageDecreaseRatio;
     type StakingRatio = StakingRatio;
     type RenewRewardRatio = RenewRewardRatio;
-    type TaxRatio = TaxRatio;
+    type StorageRatio = StorageRatio;
     type UsedTrashMaxSize = UsedTrashMaxSize;
     type MaximumFileSize = MaximumFileSize;
     type WeightInfo = weight::WeightInfo<Test>;
@@ -211,6 +209,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     ext.execute_with(|| {
         init_swork_setup();
         assert_ok!(Market::set_market_switch(Origin::root(), true));
+        assert_ok!(Market::set_base_fee(Origin::root(), 1000));
     });
 
     ext

--- a/cstrml/staking/Cargo.toml
+++ b/cstrml/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-staking"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/staking/src/weight.rs
+++ b/cstrml/staking/src/weight.rs
@@ -24,6 +24,13 @@ impl crate::WeightInfo for WeightInfo {
 			.saturating_add(DbWeight::get().reads(8 as Weight))
 			.saturating_add(DbWeight::get().writes(5 as Weight))
 	}
+	fn rebond(l: u32, ) -> Weight {
+		(37_039_000 as Weight)
+			// Standard Error: 2_000
+			.saturating_add((93_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
 	fn withdraw_unbonded() -> Weight {
 		(34_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(4 as Weight))

--- a/cstrml/swork/Cargo.toml
+++ b/cstrml/swork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-swork"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/swork/benchmarking/Cargo.toml
+++ b/cstrml/swork/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstrml-swork-benchmarking"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cstrml/swork/benchmarking/src/mock.rs
+++ b/cstrml/swork/benchmarking/src/mock.rs
@@ -4,7 +4,7 @@
 use crate::*;
 
 pub use frame_support::{
-    parameter_types,
+    parameter_types, assert_ok,
     weights::{Weight, constants::RocksDbWeight},
     traits::{OnInitialize, OnFinalize, Get, TestRandomness}
 };
@@ -79,13 +79,12 @@ parameter_types! {
     pub const MarketModuleId: ModuleId = ModuleId(*b"crmarket");
     pub const FileDuration: BlockNumber = 1000;
     pub const FileReplica: u32 = 4;
-    pub const FileBaseFee: Balance = 1000;
     pub const FileInitPrice: Balance = 1000; // Need align with FileDuration and FileBaseReplica
     pub const StorageReferenceRatio: (u128, u128) = (1, 2);
     pub const StorageIncreaseRatio: Perbill = Perbill::from_percent(1);
     pub const StorageDecreaseRatio: Perbill = Perbill::from_percent(1);
-    pub const StakingRatio: Perbill = Perbill::from_percent(80);
-    pub const TaxRatio: Perbill = Perbill::from_percent(10);
+    pub const StakingRatio: Perbill = Perbill::from_percent(72);
+    pub const StorageRatio: Perbill = Perbill::from_percent(18);
     pub const UsedTrashMaxSize: u128 = 2;
     pub const MaximumFileSize: u64 = 137_438_953_472; // 128G = 128 * 1024 * 1024 * 1024
     pub const RenewRewardRatio: Perbill = Perbill::from_percent(5);
@@ -100,14 +99,13 @@ impl market::Config for Test {
     /// File duration.
     type FileDuration = FileDuration;
     type FileReplica = FileReplica;
-    type FileBaseFee = FileBaseFee;
     type FileInitPrice = FileInitPrice;
     type StorageReferenceRatio = StorageReferenceRatio;
     type StorageIncreaseRatio = StorageIncreaseRatio;
     type StorageDecreaseRatio = StorageDecreaseRatio;
     type StakingRatio = StakingRatio;
     type RenewRewardRatio = RenewRewardRatio;
-    type TaxRatio = TaxRatio;
+    type StorageRatio = StorageRatio;
     type UsedTrashMaxSize = UsedTrashMaxSize;
     type MaximumFileSize = MaximumFileSize;
     type WeightInfo = market::weight::WeightInfo<Test>;
@@ -166,6 +164,12 @@ impl ExtBuilder {
             .build_storage::<Test>()
             .unwrap();
 
-        t.into()
+        let mut ext: sp_io::TestExternalities = t.into();
+        ext.execute_with(|| {
+            assert_ok!(Market::set_market_switch(Origin::root(), true));
+            assert_ok!(Market::set_base_fee(Origin::root(), 1000));
+        });
+
+        ext
     }
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crust"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 build = "build.rs"
 edition = "2018"
@@ -45,11 +45,11 @@ frame-benchmarking-cli = { optional = true, version = "3.0.0" }
 frame-benchmarking = "3.0.0"
 
 # crust runtime modules
-crust-runtime = { path = "../runtime", version = "0.11.1" }
-cstrml-staking = { path = "../cstrml/staking", version = "0.11.1" }
-cstrml-swork = { path = "../cstrml/swork", version = "0.11.1" }
-primitives = { package = "cst-primitives", path = "../primitives", version = "0.11.1" }
-crust-rpc = { path =  "../rpc", version = "0.11.1" }
+crust-runtime = { path = "../runtime", version = "0.12.0" }
+cstrml-staking = { path = "../cstrml/staking", version = "0.12.0" }
+cstrml-swork = { path = "../cstrml/swork", version = "0.12.0" }
+primitives = { package = "cst-primitives", path = "../primitives", version = "0.12.0" }
+crust-rpc = { path =  "../rpc", version = "0.12.0" }
 
 [build-dependencies]
 substrate-build-script-utils = "3.0.0"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -214,13 +214,14 @@ fn testnet_genesis(
             code: wasm_binary.to_vec(),
             changes_trie_config: Default::default(),
         }),
-        balances: Some(BalancesConfig {
+        balances_Instance1: Some(BalancesConfig {
             balances: endowed_accounts
                 .iter()
                 .cloned()
                 .map(|k| (k, ENDOWMENT))
                 .collect(),
         }),
+        balances_Instance2: Some(Default::default()),
         pallet_indices: Some(IndicesConfig {
             indices: vec![],
         }),
@@ -336,13 +337,14 @@ fn rocky_staging_testnet_config_genesis(wasm_binary: &[u8]) -> GenesisConfig {
             code: wasm_binary.to_vec(),
             changes_trie_config: Default::default(),
         }),
-        balances: Some(BalancesConfig {
+        balances_Instance1: Some(BalancesConfig {
             balances: endowed_accounts
                 .iter()
                 .cloned()
                 .map(|k| (k, ENDOWMENT))
                 .collect(),
         }),
+        balances_Instance2: Some(Default::default()),
         pallet_indices: Some(IndicesConfig {
             indices: vec![],
         }),
@@ -457,13 +459,14 @@ fn maxwell_staging_testnet_config_genesis(wasm_binary: &[u8]) -> GenesisConfig {
             code: wasm_binary.to_vec(),
             changes_trie_config: Default::default(),
         }),
-        balances: Some(BalancesConfig {
+        balances_Instance1: Some(BalancesConfig {
             balances: endowed_accounts
                 .iter()
                 .cloned()
                 .map(|k| (k, ENDOWMENT))
                 .collect(),
         }),
+        balances_Instance2: Some(Default::default()),
         pallet_indices: Some(IndicesConfig {
             indices: vec![],
         }),

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cst-primitives"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["crustio"]
 edition = "2018"
 license = "GPL-3.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -2,8 +2,8 @@
 authors = ["crustio"]
 edition = "2018"
 name = "crust-rpc"
-version = "0.11.1"
-license = "GPL-3.0"
+version = "0.12.0"
+license = "Apache-2.0"
 homepage = "https://crust.network"
 repository = "https://github.com/crustio/crust/"
 
@@ -34,5 +34,5 @@ pallet-transaction-payment-rpc = "3.0.0"
 sp-block-builder = "3.0.0"
 
 # crust dependent
-crust-primitives = { package = "cst-primitives", path="../primitives", version = "0.11.1" }
-crust-runtime = { package = "crust-runtime", path = "../runtime", version = "0.11.1" }
+crust-primitives = { package = "cst-primitives", path="../primitives", version = "0.12.0" }
+crust-runtime = { package = "crust-runtime", path = "../runtime", version = "0.12.0" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["crustio"]
 edition = "2018"
 name = "crust-runtime"
-version = "0.11.1"
+version = "0.12.0"
 build = "build.rs"
 license = "GPL-3.0"
 homepage = "https://crust.network"
@@ -72,16 +72,16 @@ frame-system-rpc-runtime-api = { default-features = false, version = "3.0.0" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "3.0.0" }
 
 # crust runtime modules
-balances = { package = "cstrml-balances", path = "../cstrml/balances", default-features = false, version = "0.11.1" }
-candy = { package = "cstrml-candy", path = "../cstrml/candy", default-features = false, version = "0.11.1"  }
-claims = { package = "cstrml-claims", path = "../cstrml/claims", default-features = false, version = "0.11.1" }
-market = { package = "cstrml-market", path = "../cstrml/market", default-features = false, version = "0.11.1" }
-primitives = { package = "cst-primitives", path = "../primitives", default-features = false, version = "0.11.1" }
-swork = { package = "cstrml-swork", path = "../cstrml/swork", default-features = false, version = "0.11.1" }
-staking = { package = "cstrml-staking", path = "../cstrml/staking", default-features = false, version = "0.11.1" }
-
+balances = { package = "cstrml-balances", path = "../cstrml/balances", default-features = false, version = "0.12.0" }
+candy = { package = "cstrml-candy", path = "../cstrml/candy", default-features = false, version = "0.12.0"  }
+claims = { package = "cstrml-claims", path = "../cstrml/claims", default-features = false, version = "0.12.0" }
+market = { package = "cstrml-market", path = "../cstrml/market", default-features = false, version = "0.12.0" }
+primitives = { package = "cst-primitives", path = "../primitives", default-features = false, version = "0.12.0" }
+swork = { package = "cstrml-swork", path = "../cstrml/swork", default-features = false, version = "0.12.0" }
+staking = { package = "cstrml-staking", path = "../cstrml/staking", default-features = false, version = "0.12.0" }
+csm-locking = { package = "cstrml-csm-locking", path = "../cstrml/csm-locking", default-features = false, version = "0.12.0" }
 # crust benchmark dependencies
-swork-benchmarking = { package = "cstrml-swork-benchmarking", path = "../cstrml/swork/benchmarking", default-features = false, optional = true, version = "0.11.1" }
+swork-benchmarking = { package = "cstrml-swork-benchmarking", path = "../cstrml/swork/benchmarking", default-features = false, optional = true, version = "0.12.0" }
 
 [features]
 default = ["std"]
@@ -129,6 +129,7 @@ std = [
     'staking/std',
     'pallet-sudo/std',
     'swork/std',
+    "csm-locking/std",
     'frame-system/std',
     'frame-system-rpc-runtime-api/std',
     'pallet-timestamp/std',
@@ -136,7 +137,7 @@ std = [
     'pallet-transaction-payment/std',
     'pallet-transaction-payment-rpc-runtime-api/std',
     'pallet-treasury/std',
-    'pallet-utility/std',
+    'pallet-utility/std'
 ]
 runtime-benchmarks = [
     "frame-benchmarking",
@@ -148,5 +149,6 @@ runtime-benchmarks = [
     "frame-system-benchmarking",
     "staking/runtime-benchmarks",
     "market/runtime-benchmarks",
+    "csm-locking/runtime-benchmarks",
     "swork-benchmarking"
 ]


### PR DESCRIPTION
* Prepping v0.12.0 (#567)

Co-authored-by: MyronFanQiu <49134743+MyronFanQiu@users.noreply.github.com>

* [Market] Switch to storage and support change base fee online (#569)

* [Market] Switch to storage and support change base fee online

* Refine comment

* [GPoS] Support rebond extrinsic (#577)

* [GPoS] Support rebond functionality

* format

* format

* format

* [Market] Refine squencial of split money (#565)

Co-authored-by: Kun <zikunvan@gmail.com>

* [Runtime] Add CSM module (#583)

[Runtime] Add CSM Module

* [CSM] Support locking CSM (#584)

* [CSM] Support locking CSM

* Refine space

* refine comments

* refine space

* Renmae

* refine comments

fix

fix runtime

* remove migration and bump version to 23

* fix error caused by cherry-pic

Co-authored-by: Kun <zikunvan@gmail.com>