### PR TITLE
[GPoS] Dynamic Authoring and Staking Reward Ratio

### DIFF
--- a/cstrml/staking/src/lib.rs
+++ b/cstrml/staking/src/lib.rs
@@ -2077,7 +2077,7 @@ impl<T: Config> Module<T> {
                 total_payout = total_payout.saturating_sub(used_fee);
 
                 // 5. Split the payout for staking and authoring
-                let num_of_validators = points.individual.len();
+                let num_of_validators = Self::current_elected().len();
                 let total_authoring_payout = Self::get_authoring_and_staking_reward_ratio(num_of_validators as u32) * total_payout;
                 let total_staking_payout = total_payout.saturating_sub(total_authoring_payout);
 

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -262,7 +262,6 @@ parameter_types! {
     pub const MaxGuarantorRewardedPerValidator: u32 = 4;
     pub const SPowerRatio: u128 = 2_500;
     pub const MarketStakingPotDuration: u32 = 5;
-    pub const AuthoringAndStakingRatio: Perbill = Perbill::from_percent(20);
 }
 
 impl Config for Test {
@@ -284,7 +283,6 @@ impl Config for Test {
     type SPowerRatio = SPowerRatio;
     type MarketStakingPot = TestStaking;
     type MarketStakingPotDuration = MarketStakingPotDuration;
-    type AuthoringAndStakingRatio = AuthoringAndStakingRatio;
     type BenefitInterface = TestBenefitInterface;
     type WeightInfo = weight::WeightInfo;
 }

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -470,7 +470,7 @@ fn era_reward_with_dsm_staking_pot_should_work() {
             // Compute now as other parameter won't change
             let total_authoring_payout = authoring_rewards_in_era(Staking::current_era().unwrap_or(0));
             let total_staking_payout_0 = staking_rewards_in_era(Staking::current_era().unwrap_or(0));
-            let market_authoring_payout = <<Test as Config>::AuthoringAndStakingRatio>::get() * dsm_staking_payout_per_era;
+            let market_authoring_payout = Staking::get_authoring_and_staking_reward_ratio(10) * dsm_staking_payout_per_era;
             let market_staking_payout = dsm_staking_payout_per_era - market_authoring_payout;
             assert!(total_staking_payout_0 > 10); // Test is meaningful if reward something
             assert_eq!(Staking::eras_total_stakes(0), 2001);
@@ -5147,6 +5147,32 @@ fn change_validator_count_should_work() {
                 5
             ));
             assert_eq!(Staking::validator_count(), 15);
+        });
+}
+
+#[test]
+fn change_authoring_reward_ratio_according_to_validator_count_should_work() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(|| {
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(0), Perbill::from_percent(20));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(200), Perbill::from_percent(20));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(500), Perbill::from_percent(20));
+
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(501), Perbill::from_percent(25));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(700), Perbill::from_percent(25));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(1000), Perbill::from_percent(25));
+
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(1001), Perbill::from_percent(30));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(2000), Perbill::from_percent(30));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(2500), Perbill::from_percent(30));
+
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(2501), Perbill::from_percent(40));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(4000), Perbill::from_percent(40));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(5000), Perbill::from_percent(40));
+
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(5001), Perbill::from_percent(50));
+            assert_eq!(Staking::get_authoring_and_staking_reward_ratio(u32::max_value()), Perbill::from_percent(50));
         });
 }
 

--- a/cstrml/staking/src/tests.rs
+++ b/cstrml/staking/src/tests.rs
@@ -4627,6 +4627,7 @@ fn new_era_with_stake_limit_should_work() {
                 }
             );
             assert_eq!(Staking::current_elected(), vec![11, 21, 31, 7]);
+            assert_eq!(Staking::current_elected().len(), 4);
         });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -405,8 +405,6 @@ parameter_types! {
     pub const MaxGuarantorRewardedPerValidator: u32 = 64;
     // 60 eras means 15 days if era = 6 hours
     pub const MarketStakingPotDuration: u32 = 60;
-    // Authoring and Staking reward ratio
-    pub const AuthoringAndStakingRatio: Perbill = Perbill::from_percent(20);
 }
 
 impl staking::Config for Runtime {
@@ -431,7 +429,6 @@ impl staking::Config for Runtime {
     type SPowerRatio = SPowerRatio;
     type MarketStakingPot = Market;
     type MarketStakingPotDuration = MarketStakingPotDuration;
-    type AuthoringAndStakingRatio = AuthoringAndStakingRatio;
     type BenefitInterface = Benefits;
     type WeightInfo = staking::weight::WeightInfo;
 }


### PR DESCRIPTION
If era's length is 6 hours, max validators would be 3600. 5000 is useless.