### PR TITLE
[Runtime] Change unboding duration, market base fee curve and minimum balance

### DIFF
--- a/cstrml/balances/src/lib.rs
+++ b/cstrml/balances/src/lib.rs
@@ -156,7 +156,7 @@ mod benchmarking;
 pub mod weights;
 
 use sp_std::prelude::*;
-use sp_std::{cmp, result, mem, fmt::Debug, ops::BitOr};
+use sp_std::{cmp, result, fmt::Debug, ops::BitOr};
 use codec::{Codec, Encode, Decode};
 use frame_support::{
 	ensure,

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -952,24 +952,13 @@ impl<T: Config> Module<T> {
             // New order => check the alpha
             Some(alpha) => {
                 match alpha {
-                    0 ..= 5 => (false, Perbill::from_percent(30)),
-                    6 => (false,Perbill::from_percent(25)),
-                    7 => (false,Perbill::from_percent(21)),
-                    8 => (false,Perbill::from_percent(18)),
-                    9 => (false,Perbill::from_percent(16)),
-                    10 => (false,Perbill::from_percent(15)),
-                    11 => (false,Perbill::from_percent(13)),
-                    12 => (false,Perbill::from_percent(12)),
-                    13 => (false,Perbill::from_percent(11)),
-                    14 ..= 15 => (false,Perbill::from_percent(10)),
-                    16 => (false,Perbill::from_percent(9)),
-                    17 ..= 18 => (false,Perbill::from_percent(8)),
-                    19 ..= 21 => (false,Perbill::from_percent(7)),
-                    22 ..= 25 => (false,Perbill::from_percent(6)),
-                    26 ..= 30 => (false,Perbill::from_percent(5)),
-                    31 ..= 37 => (false,Perbill::from_percent(4)),
-                    38 ..= 49 => (false,Perbill::from_percent(3)),
-                    50 ..= 80 => (false,Perbill::zero()),
+                    0 ..= 3 => (false, Perbill::from_percent(9)),
+                    4 => (false,Perbill::from_percent(7)),
+                    5 => (false,Perbill::from_percent(6)),
+                    6 => (false,Perbill::from_percent(5)),
+                    7 => (false,Perbill::from_percent(4)),
+                    8 ..= 9 => (false,Perbill::from_percent(3)),
+                    10 ..= 30 => (false,Perbill::zero()),
                     _ => (true, Perbill::from_percent(3))
                 }
             },

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -1658,27 +1658,27 @@ fn update_base_fee_should_work() {
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
 
-        // alpha == 50 => keep same
-        <swork::AddedFilesCount>::put(500);
+        // alpha == 20 => keep same
+        <swork::AddedFilesCount>::put(200);
         OrdersCount::put(10);
         Market::update_base_fee();
         assert_eq!(Market::file_base_fee(), 970);
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
 
-        // alpha == 0 => increase 30%
+        // alpha == 0 => increase 9%
         <swork::AddedFilesCount>::put(0);
         OrdersCount::put(100);
         Market::update_base_fee();
-        assert_eq!(Market::file_base_fee(), 1261);
+        assert_eq!(Market::file_base_fee(), 1057);
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
 
-        // alpha == 11 => increase 13%
-        <swork::AddedFilesCount>::put(110);
+        // alpha == 6 => increase 5%
+        <swork::AddedFilesCount>::put(60);
         OrdersCount::put(10);
         Market::update_base_fee();
-        assert_eq!(Market::file_base_fee(), 1425);
+        assert_eq!(Market::file_base_fee(), 1110);
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
 
@@ -1686,7 +1686,7 @@ fn update_base_fee_should_work() {
         <swork::AddedFilesCount>::put(1500);
         OrdersCount::put(10);
         Market::update_base_fee();
-        assert_eq!(Market::file_base_fee(), 1382);
+        assert_eq!(Market::file_base_fee(), 1077);
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
     });

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -91,5 +91,5 @@ pub mod market {
     #[cfg(feature = "test")]
     pub const COLLATERAL_RATIO: u32 = 10;
     #[cfg(not(feature = "test"))]
-    pub const COLLATERAL_RATIO: u32 = 5;
+    pub const COLLATERAL_RATIO: u32 = 1;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -391,10 +391,10 @@ parameter_types! {
     pub const StakingModuleId: ModuleId = ModuleId(*b"cstaking");
     // 6 sessions in an era (6 hours).
     pub const SessionsPerEra: SessionIndex = 6;
-    // 60 eras for unbonding (15 days).
-    pub const BondingDuration: EraIndex = 60;
-    // 28 eras in which slashes can be cancelled (slightly less than 7 days).
-    pub const SlashDeferDuration: EraIndex = 27;
+    // 112 eras for unbonding (28 days).
+    pub const BondingDuration: EraIndex = 28 * 4;
+    // 108 eras in which slashes can be cancelled (slightly less than 28 days).
+    pub const SlashDeferDuration: EraIndex = 27 * 4;
     // 1 * CRUs / TB, since we treat 1 TB = 1_000_000_000_000, so the ratio = `1`
     pub const SPowerRatio: u128 = 1;
     // 64 guarantors for one validator.
@@ -441,7 +441,7 @@ impl pallet_offences::Config for Runtime {
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u128 = 1 * MILLICENTS;
+    pub const ExistentialDeposit: u128 = 10 * MILLICENTS;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -788,7 +788,7 @@ impl market::Config for Runtime {
 
 parameter_types! {
     pub const BenefitReportWorkCost: Balance = 3 * DOLLARS;
-    pub const BenefitsLimitRatio: Perbill = Perbill::from_rational_approximation(2, 1000);
+    pub BenefitsLimitRatio: Perbill = Perbill::from_rational_approximation(2u64, 1000);
     pub const BenefitMarketCostRatio: Perbill = Perbill::one();
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -788,7 +788,7 @@ impl market::Config for Runtime {
 
 parameter_types! {
     pub const BenefitReportWorkCost: Balance = 3 * DOLLARS;
-    pub const BenefitsLimitRatio: Perbill = Perbill::from_percent(1);
+    pub const BenefitsLimitRatio: Perbill = Perbill::from_rational_approximation(2, 1000);
     pub const BenefitMarketCostRatio: Perbill = Perbill::one();
 }
 


### PR DESCRIPTION
1. Unboding duration to 112 eras
2. New market base fee curve
3. minimum balance to 0.0001
4. BenefitsLimitRatio to 0.2%
5. COLLATERAL_RATIO to 1

Action: need to transfer 0.0001 to four market's pots