### PR TITLE
[Market] Add minimal file fee and some refraction

### DIFF
--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -830,22 +830,22 @@ fn update_file_byte_fee_per_blocks_should_work() {
         Market::on_initialize(6);
         assert_eq!(Market::file_byte_fee(), 1000);
         // update file price
-        Market::on_initialize(7);
+        Market::on_initialize(597);
         assert_eq!(Market::file_byte_fee(), 990);
         <swork::Free>::put(10000);
         <swork::ReportedFilesSize>::put(10000);
         // no new order => don't update
-        Market::on_initialize(17);
+        Market::on_initialize(1197);
         assert_eq!(Market::file_byte_fee(), 990);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
         // 26 + 3 % 10 is not zero
-        Market::on_initialize(26);
+        Market::on_initialize(1796);
         assert_eq!(Market::file_byte_fee(), 990);
         // update file price
-        Market::on_initialize(27);
+        Market::on_initialize(1797);
         assert_eq!(Market::file_byte_fee(), 980);
     });
 }
@@ -866,60 +866,60 @@ fn update_file_keys_count_fee_per_blocks_should_work() {
 
         // 6 + 3 % 10 is not zero
         <FileKeysCountFee<Test>>::put(1000);
-        Market::on_initialize(6);
+        Market::on_initialize(596);
         assert_eq!(Market::file_keys_count_fee(), 1000);
         // update file price
-        Market::on_initialize(7);
+        Market::on_initialize(597);
         assert_eq!(Market::file_keys_count_fee(), 990);
         // no new order => don't update
-        Market::on_initialize(17);
+        Market::on_initialize(1197);
         assert_eq!(Market::file_keys_count_fee(), 990);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
         // 26 + 3 % 10 is not zero
-        Market::on_initialize(26);
+        Market::on_initialize(1796);
         assert_eq!(Market::file_keys_count_fee(), 990);
         // update file price
-        Market::on_initialize(27);
+        Market::on_initialize(1797);
         assert_eq!(Market::file_keys_count_fee(), 980);
 
         // price is 40 and cannot decrease
         <FileKeysCountFee<Test>>::put(40);
-        FileKeysCount::put(20_000_000);
+        FileKeysCount::put(2_000_000);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
-        Market::on_initialize(37);
+        Market::on_initialize(2397);
         assert_eq!(Market::file_keys_count_fee(), 40);
 
         // price is 40 and will increase by 1
-        FileKeysCount::put(20_000_001);
+        FileKeysCount::put(2_000_001);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
-        Market::on_initialize(37);
+        Market::on_initialize(2397);
         assert_eq!(Market::file_keys_count_fee(), 41);
 
         <MinFileKeysCountFee<Test>>::put(80);
-        FileKeysCount::put(20_000_000);
+        FileKeysCount::put(2_000_000);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
-        Market::on_initialize(37);
+        Market::on_initialize(2397);
         assert_eq!(Market::file_keys_count_fee(), 80);
 
         // price is 80 and will increase by 1
-        FileKeysCount::put(20_000_001);
+        FileKeysCount::put(2_000_001);
         assert_ok!(Market::place_storage_order(
             Origin::signed(source.clone()), cid.clone(),
             file_size, 0, vec![]
         ));
-        Market::on_initialize(37);
+        Market::on_initialize(2397);
         assert_eq!(Market::file_keys_count_fee(), 81);
     });
 }

--- a/cstrml/market/src/tests.rs
+++ b/cstrml/market/src/tests.rs
@@ -739,6 +739,16 @@ fn update_file_byte_fee_should_work() {
         <swork::ReportedFilesSize>::put(60000);
         Market::update_file_byte_fee();
         assert_eq!(Market::file_byte_fee(), 41);
+
+        // price is 40 and cannot decrease
+        <MinFileByteFee<Test>>::put(80);
+        <swork::ReportedFilesSize>::put(1000);
+        Market::update_file_byte_fee();
+        assert_eq!(Market::file_byte_fee(), 80);
+
+        <swork::ReportedFilesSize>::put(1000);
+        Market::update_file_byte_fee();
+        assert_eq!(Market::file_byte_fee(), 80);
     });
 }
 
@@ -786,6 +796,19 @@ fn update_base_fee_should_work() {
         assert_eq!(Market::file_base_fee(), 1169);
         assert_eq!(Swork::added_files_count(), 0);
         assert_eq!(Market::orders_count(), 0);
+
+
+        // price is 40 and cannot decrease
+        <MinFileBaseFee<Test>>::put(1300);
+        <swork::AddedFilesCount>::put(1500);
+        OrdersCount::put(10);
+        Market::update_base_fee();
+        assert_eq!(Market::file_base_fee(), 1300);
+
+        <swork::AddedFilesCount>::put(60);
+        OrdersCount::put(10);
+        Market::update_base_fee();
+        assert_eq!(Market::file_base_fee(), 1404);
     });
 }
 
@@ -880,6 +903,24 @@ fn update_file_keys_count_fee_per_blocks_should_work() {
         ));
         Market::on_initialize(37);
         assert_eq!(Market::file_keys_count_fee(), 41);
+
+        <MinFileKeysCountFee<Test>>::put(80);
+        FileKeysCount::put(20_000_000);
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 0, vec![]
+        ));
+        Market::on_initialize(37);
+        assert_eq!(Market::file_keys_count_fee(), 80);
+
+        // price is 80 and will increase by 1
+        FileKeysCount::put(20_000_001);
+        assert_ok!(Market::place_storage_order(
+            Origin::signed(source.clone()), cid.clone(),
+            file_size, 0, vec![]
+        ));
+        Market::on_initialize(37);
+        assert_eq!(Market::file_keys_count_fee(), 81);
     });
 }
 

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -78,9 +78,9 @@ pub mod market {
     pub const BASE_FEE_UPDATE_SLOT: u32 = 600;
     pub const BASE_FEE_UPDATE_OFFSET: u32 = 22;
 
-    pub const PRICE_UPDATE_SLOT: u32 = 10;
+    pub const PRICE_UPDATE_SLOT: u32 = 600;
     pub const PRICE_UPDATE_OFFSET: u32 = 3;
-    pub const FILES_COUNT_REFERENCE: u32 = 20_000_000; // 20_000_000 / 50_000_000 = 40%
+    pub const FILES_COUNT_REFERENCE: u32 = 2_000_000; // 2_000_000 / 50_000_000 = 40% // Try 2M first
 
     pub const SPOWER_UPDATE_SLOT: u32 = 100;
     pub const SPOWER_UPDATE_OFFSET: u32 = 7;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -762,8 +762,8 @@ parameter_types! {
     pub const InitFileByteFee: Balance = MILLICENTS / 1000; // Need align with FileDuration and FileReplica
     pub const InitFileKeysCountFee: Balance = MILLICENTS / 10;
     pub const StorageReferenceRatio: (u128, u128) = (50, 100); // 50/100 = 50%
-    pub StorageIncreaseRatio: Perbill = Perbill::from_rational_approximation(6u64, 100000);
-    pub StorageDecreaseRatio: Perbill = Perbill::from_rational_approximation(5u64, 100000);
+    pub StorageIncreaseRatio: Perbill = Perbill::from_rational_approximation(33u64, 10000);
+    pub StorageDecreaseRatio: Perbill = Perbill::from_rational_approximation(3u64, 1000);
     pub const StakingRatio: Perbill = Perbill::from_percent(72);
     pub const StorageRatio: Perbill = Perbill::from_percent(18);
     pub const MaximumFileSize: u64 = 8_589_934_592; // 8G = 8 * 1024 * 1024 * 1024


### PR DESCRIPTION
1. Add minimal price for all prices
2. Support setting the prices through extrinsics
3. Decrease the key count reference to 2M first
4. Decrease the file update frequency to 1 hour instead of 1 minute