### PR TITLE
Upgrade the spec_version from 5 to 6, to reflect the changes including in this parachain/fix-bridge-transfer up until now.

### DIFF
--- a/crust-collator/runtime/src/lib.rs
+++ b/crust-collator/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot-crust-parachain"),
 	impl_name: create_runtime_str!("polkadot-crust-parachain"),
 	authoring_version: 1,
-	spec_version: 5,
+	spec_version: 6,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Upgrade the spec_version from 5 to 6, to reflect the changes including in this parachain/fix-bridge-transfer up until now.