### PR TITLE
Add support to set spower superior account

### DIFF
--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -357,6 +357,9 @@ decl_storage! {
 
         /// The sPower will become valid after this period, default is 3 months
         pub SpowerReadyPeriod get(fn spower_ready_period): BlockNumber = 1_296_000;
+
+        /// The crust-spower service account
+        pub SpowerSuperior get(fn spower_superior): Option<T::AccountId>;
     }
     add_extra_genesis {
 		build(|_config| {
@@ -525,6 +528,17 @@ decl_module! {
 
             Self::deposit_event(RawEvent::AddPrepaidSuccess(who, cid, amount));
 
+            Ok(())
+        }
+
+        /// Set the crust-spower service superior account
+        #[weight = 1000]
+        pub fn set_spower_superior(origin, superior: T::AccountId) -> DispatchResult {
+            ensure_root(origin)?;
+
+            SpowerSuperior::<T>::put(superior.clone());
+
+            Self::deposit_event(RawEvent::SetSpowerSuperiorSuccess(superior));
             Ok(())
         }
 
@@ -1170,5 +1184,7 @@ decl_event!(
         SetEnableMarketSuccess(bool),
         /// Set the file base fee success.
         SetBaseFeeSuccess(Balance),
+        /// Set the crust-spower service superior account.
+        SetSpowerSuperiorSuccess(AccountId),
     }
 );

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -241,6 +241,9 @@ decl_storage! {
         pub WorkReports get(fn work_reports):
             map hasher(twox_64_concat) SworkerAnchor => Option<WorkReport>;
 
+        /// The crust-spower service account
+        pub SpowerSuperior get(fn spower_superior): Option<T::AccountId>;
+
         /// The current report slot block number, this value should be a multiple of report slot block.
         pub CurrentReportSlot get(fn current_report_slot): ReportSlot = 0;
 
@@ -720,6 +723,17 @@ decl_module! {
             }
 
             Ok(Pays::Yes.into())
+        }
+
+        /// Set the crust-spower service superior account
+        #[weight = 1000]
+        pub fn set_spower_superior(origin, superior: T::AccountId) -> DispatchResult {
+            ensure_root(origin)?;
+
+            SpowerSuperior::<T>::put(superior.clone());
+
+            Self::deposit_event(RawEvent::SetSpowerSuperiorSuccess(superior));
+            Ok(())
         }
 
         /// Create a group. One account can only create one group once.
@@ -1471,5 +1485,7 @@ decl_event!(
         SetPunishmentSuccess(bool),
         /// Remove the expired code success
         RemoveCodeSuccess(SworkerCode),
+        /// Set the crust-spower service superior account.
+        SetSpowerSuperiorSuccess(AccountId),
     }
 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("crust"),
     impl_name: create_runtime_str!("crustio-crust"),
     authoring_version: 1,
-    spec_version: 21,
+    spec_version: 22,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1


### PR DESCRIPTION
Add support to set spower superior account.

This is a pre merge commit for the offchain spower calculation feature. We will upgrade this runtime first to set the spower superior beforehand, so that after we upgrade the actual runtime which contains the offchain spower feature, the crust-spower service can run directly without any wait time.