### PR TITLE
Implement the calculate spower offchain feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 ## Integration test
 db/
+
+# logs
+*.log

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -118,31 +118,6 @@ pub struct ReplicaToUpdate<AccountId> {
 }
 type ReplicaToUpdateOf<T> = ReplicaToUpdate<<T as system::Config>::AccountId>; 
 
-
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct FileReplicaToUpdate<AccountId> {
-    pub reporter: AccountId,
-    pub owner: AccountId,
-    pub sworker_anchor: SworkerAnchor,
-    pub report_slot: ReportSlot,
-    pub report_block: BlockNumber,
-    pub valid_at: BlockNumber,
-    pub is_added: bool
-}
-type FileReplicaToUpdateOf<T> = FileReplicaToUpdate<<T as system::Config>::AccountId>; 
-
-#[derive(Debug, PartialEq, Clone, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct FileInfoToUpdate<AccountId: Ord, Balance> {
-    pub existing_file_info: FileInfoV2<AccountId, Balance>,
-    // The first report block number where the existing_file_info is set
-    pub report_block: BlockNumber,
-    pub actual_added_replicas: Vec<FileReplicaToUpdate<AccountId>>,
-    pub actual_deleted_replicas: Vec<FileReplicaToUpdate<AccountId>>,
-}
-type FileInfoToUpdateOf<T> = FileInfoToUpdate<<T as system::Config>::AccountId, BalanceOf<T>>;
-
 type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance;
 type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::PositiveImbalance;
 type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::NegativeImbalance;
@@ -753,8 +728,13 @@ impl<T: Config> Module<T> {
         'file_loop: for (cid, reported_file_size, file_replicas) in file_infos_map {
 
             // Split the replicas array into added_replicas and deleted_replicas
-            let mut added_replicas: Vec<ReplicaToUpdateOf<T>> = vec![];
-            let mut deleted_replicas: Vec<ReplicaToUpdateOf<T>> = vec![];
+            // let (mut added_replicas, mut deleted_replicas):
+            //     (Vec<FileReplicaToUpdateOf<T>>,Vec<FileReplicaToUpdateOf<T>>) = file_replicas
+            //     .into_iter()
+            //     .partition(|replica| replica.is_added);
+
+            let mut added_replicas: Vec<FileReplicaToUpdateOf<T>> = vec![];
+            let mut deleted_replicas: Vec<FileReplicaToUpdateOf<T>> = vec![];
             for replica in file_replicas {
                 if replica.is_added {
                     added_replicas.push(replica);

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -118,6 +118,37 @@ pub struct ReplicaToUpdate<AccountId> {
 }
 type ReplicaToUpdateOf<T> = ReplicaToUpdate<<T as system::Config>::AccountId>; 
 
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct FileReplicaToUpdate<AccountId> {
+    pub reporter: AccountId,
+    pub owner: AccountId,
+    pub sworker_anchor: SworkerAnchor,
+    pub report_slot: ReportSlot,
+    pub report_block: BlockNumber,
+    pub valid_at: BlockNumber,
+    pub is_added: bool
+}
+type FileReplicaToUpdateOf<T> = FileReplicaToUpdate<<T as system::Config>::AccountId>; 
+
+#[derive(Debug, PartialEq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct FileInfoToUpdate<AccountId: Ord, Balance> {
+    pub existing_file_info: FileInfoV2<AccountId, Balance>,
+    // The first report block number where the existing_file_info is set
+    pub report_block: BlockNumber,
+    pub actual_added_replicas: Vec<FileReplicaToUpdate<AccountId>>,
+    pub actual_deleted_replicas: Vec<FileReplicaToUpdate<AccountId>>,
+}
+type FileInfoToUpdateOf<T> = FileInfoToUpdate<<T as system::Config>::AccountId, BalanceOf<T>>;
+
+type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance;
+type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::PositiveImbalance;
+type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::NegativeImbalance;
+
+impl<T: Config> MarketInterface<<T as system::Config>::AccountId, BalanceOf<T>> for Module<T>
+{
 type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance;
 type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::PositiveImbalance;
 type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::NegativeImbalance;

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -104,7 +104,6 @@ pub struct Replica<AccountId> {
     pub created_at: Option<BlockNumber>
 }
 
-
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ReplicaToUpdate<AccountId> {
@@ -118,12 +117,6 @@ pub struct ReplicaToUpdate<AccountId> {
 }
 type ReplicaToUpdateOf<T> = ReplicaToUpdate<<T as system::Config>::AccountId>; 
 
-type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance;
-type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::PositiveImbalance;
-type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::NegativeImbalance;
-
-impl<T: Config> MarketInterface<<T as system::Config>::AccountId, BalanceOf<T>> for Module<T>
-{
 type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance;
 type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::PositiveImbalance;
 type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as system::Config>::AccountId>>::NegativeImbalance;
@@ -733,8 +726,8 @@ impl<T: Config> Module<T> {
             //     .into_iter()
             //     .partition(|replica| replica.is_added);
 
-            let mut added_replicas: Vec<FileReplicaToUpdateOf<T>> = vec![];
-            let mut deleted_replicas: Vec<FileReplicaToUpdateOf<T>> = vec![];
+            let mut added_replicas: Vec<ReplicaToUpdateOf<T>> = vec![];
+            let mut deleted_replicas: Vec<ReplicaToUpdateOf<T>> = vec![];
             for replica in file_replicas {
                 if replica.is_added {
                     added_replicas.push(replica);
@@ -808,7 +801,7 @@ impl<T: Config> Module<T> {
             // --- Handle delete replicas ---
             for file_replica in deleted_replicas.iter() {
 
-                let ReplicaToUpdate { reporter, owner, ..} = file_replica;
+                let ReplicaToUpdate { reporter, owner, sworker_anchor, ..} = file_replica;
                 
                 let (is_replica_deleted, to_delete_spower) = Self::delete_replica(&mut file_info,&reporter, owner, &sworker_anchor);
                 if is_replica_deleted {

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -101,6 +101,8 @@ pub struct Replica<AccountId> {
     // Is reported in the last check
     pub is_reported: bool,
     // Timestamp which the replica created
+    // None: means who += spower
+    // Some: means who += file_size
     pub created_at: Option<BlockNumber>
 }
 

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -772,7 +772,7 @@ impl<T: Config> Module<T> {
             // --- Handle upsert replicas ---
             for file_replica in added_replicas.iter() {
 
-                let ReplicaToUpdate { reporter, owner, sworker_anchor, report_slot, report_block, valid_at, ..} = file_replica;
+                let ReplicaToUpdate { reporter, owner, sworker_anchor, report_slot, valid_at, ..} = file_replica;
 
                 // 1. Check if file_info.file_size == reported_file_size or not
                 let is_valid_cid = Self::maybe_upsert_file_size(&mut file_info, &reporter, &cid, reported_file_size); 
@@ -792,7 +792,7 @@ impl<T: Config> Module<T> {
                 }
 
                 // 2. Add replica data to storage
-                let is_replica_added = Self::upsert_replica(&mut file_info, &reporter, &owner, &sworker_anchor, *report_block, *valid_at);
+                let is_replica_added = Self::upsert_replica(&mut file_info, &reporter, &owner, &sworker_anchor, *valid_at);
                 // If the replica is not added (due to exceed MAX_REPLICA, or same owner reported), just ignore this replica
                 if is_replica_added {
                     // Update related sworker's changed spower
@@ -808,7 +808,7 @@ impl<T: Config> Module<T> {
             // --- Handle delete replicas ---
             for file_replica in deleted_replicas.iter() {
 
-                let ReplicaToUpdate { reporter, owner, sworker_anchor, ..} = file_replica;
+                let ReplicaToUpdate { reporter, owner, ..} = file_replica;
                 
                 let (is_replica_deleted, to_delete_spower) = Self::delete_replica(&mut file_info,&reporter, owner, &sworker_anchor);
                 if is_replica_deleted {
@@ -864,7 +864,6 @@ impl<T: Config> Module<T> {
                       who: &<T as system::Config>::AccountId,
                       owner: &<T as system::Config>::AccountId,
                       anchor: &SworkerAnchor,
-                      _report_block: BlockNumber,
                       valid_at: BlockNumber
                     ) -> bool {
 

--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -1021,10 +1021,11 @@ impl<T: Config> Module<T> {
         Ok(storage_amount)
     }
 
-    fn get_discount_ratio(who: &T::AccountId) -> Perbill {
-        let discount_max_ratio = Perbill::one().saturating_sub(T::StakingRatio::get()).saturating_sub(T::StorageRatio::get());
-        T::BenefitInterface::get_market_funds_ratio(who).min(discount_max_ratio)
-    }
+    // discount feature is not implemented yet, comment out first to remove the build warning
+    // fn get_discount_ratio(who: &T::AccountId) -> Perbill {
+    //     let discount_max_ratio = Perbill::one().saturating_sub(T::StakingRatio::get()).saturating_sub(T::StorageRatio::get());
+    //     T::BenefitInterface::get_market_funds_ratio(who).min(discount_max_ratio)
+    // }
 
 
     fn get_current_block_number() -> BlockNumber {

--- a/cstrml/market/src/mock.rs
+++ b/cstrml/market/src/mock.rs
@@ -32,6 +32,7 @@ pub const MERCHANT: AccountId32 = AccountId32::new([5u8; 32]);
 pub const DAVE: AccountId32 = AccountId32::new([6u8; 32]);
 pub const FERDIE: AccountId32 = AccountId32::new([7u8; 32]);
 pub const ZIKUN: AccountId32 = AccountId32::new([8u8; 32]);
+pub const SPOWER: AccountId32 = AccountId32::new([9u8; 32]);
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
 pub struct MockMerchantLedger {
@@ -301,8 +302,42 @@ pub fn init_swork_setup() {
 }
 
 // fake for report_works
-pub fn add_who_into_replica(cid: &MerkleRoot, reported_size: u64, who: AccountId, owner: AccountId, anchor: SworkerAnchor, created_at: Option<u32>, _maybe_members: Option<BTreeSet<AccountId>>) -> u64 {
-    Market::upsert_replica(&who, owner, cid, reported_size, &anchor, created_at.unwrap_or(TryInto::<u32>::try_into(System::block_number()).ok().unwrap())).0
+pub fn add_who_into_replica(
+    cid: &MerkleRoot, 
+    reported_size: u64, 
+    who: AccountId, 
+    owner: AccountId, 
+    anchor: SworkerAnchor, 
+    report_slot: ReportSlot,
+    report_block: BlockNumber,
+    valid_at: BlockNumber) {
+    
+    assert_ok!(Market::update_replicas(
+            Origin::signed(SPOWER.clone()), 
+            vec![(cid.clone(), 
+                  reported_size, 
+                  vec![(who.clone(), owner.clone(), anchor.clone(), report_slot, report_block, valid_at, true)]
+                )], 
+            400));
+}
+
+pub fn delete_replica(
+    cid: &MerkleRoot, 
+    reported_size: u64, 
+    who: AccountId, 
+    owner: AccountId, 
+    anchor: SworkerAnchor, 
+    report_slot: ReportSlot,
+    report_block: BlockNumber,
+    valid_at: BlockNumber) {
+    
+    assert_ok!(Market::update_replicas(
+            Origin::signed(SPOWER.clone()), 
+            vec![(cid.clone(), 
+                  reported_size, 
+                  vec![(who.clone(), owner.clone(), anchor.clone(), report_slot, report_block, valid_at, false)]
+                )], 
+            400));
 }
 
 pub fn legal_work_report_with_added_files() -> ReportWorksInfo {

--- a/cstrml/market/src/weight.rs
+++ b/cstrml/market/src/weight.rs
@@ -47,4 +47,9 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
+	fn update_replicas() -> Weight {
+		(1_000_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(500 as Weight))
+			.saturating_add(T::DbWeight::get().writes(500 as Weight))
+	}
 }

--- a/cstrml/staking/src/mock.rs
+++ b/cstrml/staking/src/mock.rs
@@ -226,10 +226,11 @@ impl swork::Works<AccountId> for TestStaking {
 }
 
 impl<AID> MarketInterface<AID, BalanceOf<Test>> for TestStaking {
-    fn upsert_replica(_: &AID, _: AID,  _: &MerkleRoot, _: u64,  _: &SworkerAnchor, _: u32) -> (u64, bool) { (0, true) }
-    fn delete_replica(_: &AID, _: AID,  _: &MerkleRoot, _: &SworkerAnchor) -> (u64, bool) { (0, true) }
     fn withdraw_staking_pot() -> BalanceOf<Test> {
         BalanceOf::<Test>::from(DSM_STAKING_PAYOUT.with(|v| *v.borrow()))
+    }
+
+    fn update_files_spower(_changed_files: &Vec<(MerkleRoot, u64, Vec<(AID, AID, SworkerAnchor, Option<primitives::BlockNumber>)>)>) {
     }
 }
 

--- a/cstrml/swork/benchmarking/src/lib.rs
+++ b/cstrml/swork/benchmarking/src/lib.rs
@@ -133,7 +133,7 @@ fn legal_work_report_with_deleted_files() -> ReportWorksInfo {
     }
 }
 
-fn add_market_files<T: Config>(files: Vec<(MerkleRoot, u64, u64)>, user: T::AccountId, pub_key: Vec<u8>) {
+fn add_market_files<T: Config>(files: Vec<(MerkleRoot, u64, u64)>, _user: T::AccountId, pub_key: Vec<u8>) {
     for (file, file_size, _) in files.clone().iter() {
         let mut replicas = BTreeMap::<T::AccountId, Replica<T::AccountId>>::new();
         for index in 0..200 {

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -187,6 +187,14 @@ impl<T: Config> SworkerInterface<T::AccountId> for Module<T> {
     fn get_owner(who: &T::AccountId) -> Option<T::AccountId> {
         Self::identities(who).unwrap_or_default().group
     }
+
+    // Clear the designated processed work reports    
+    fn clear_processed_work_reports(work_reports: &Vec<(SworkerAnchor, ReportSlot)>) {
+        for (anchor, slot) in work_reports {
+            <WorkReportsToProcess<T>>::remove(&anchor, slot);
+        }
+    }
+
 }
 
 /// The module's configuration trait.
@@ -733,10 +741,9 @@ decl_module! {
                 reporter: reporter.clone(),
                 owner: owner.clone()
             };
+            <WorkReportsToProcess<T>>::insert(&anchor, slot, work_report_metadata.clone());
 
-            <WorkReportsToProcess<T>>::insert(&anchor, slot, work_report_metadata);
-
-            // 13. Emit work report event
+            // 13. Emit work report event   
             Self::deposit_event(RawEvent::WorksReportSuccess(reporter.clone(), curr_pk.clone()));
 
             // 14. Try to free count limitation

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -780,6 +780,7 @@ decl_module! {
             }
             
             // 13. Emit work report event   
+            Self::deposit_event(RawEvent::QueueWorkReportSuccess(<system::Module<T>>::block_number(), extrinsic_index, reporter.clone(), owner.clone()));
             Self::deposit_event(RawEvent::WorksReportSuccess(reporter.clone(), curr_pk.clone()));
 
             // 14. Try to free count limitation
@@ -1560,10 +1561,11 @@ decl_event!(
         QueueWorkReportSuccess(SworkerAnchor, AccountId, AccountId),
         /// Set the crust-spower service superior account.
         SetSpowerSuperiorSuccess(AccountId),
+        /// Sworker spower update success
         /// The first item is the account who update the spower.
         /// The second item is the current block number
-        /// The third item is the updated sworkers count for sworker::WorkReports
-        /// The fourth item is the updated files count for market::FilesV2
+        /// The third item is the updated sworkers count
+        /// The fourth item is the processed report blocks count for market::UpdatedFilesToProcess
         UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32),
     }
 );

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -127,6 +127,15 @@ pub struct RegisterPayload<Public, AccountId> {
     public: Public
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct WorkReportMetadata<AccountId> {
+    pub block_number: BlockNumber,
+    pub extrinsic_index: u32,
+    pub reporter: AccountId,
+    pub owner: AccountId
+}
+
 /// An event handler for reporting works
 pub trait Works<AccountId> {
     fn report_works(workload_map: BTreeMap<AccountId, u128>, total_workload: u128) -> Weight;

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -130,7 +130,7 @@ pub struct RegisterPayload<Public, AccountId> {
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct WorkReportMetadata<AccountId> {
-    pub block_number: BlockNumber,
+    pub report_block: BlockNumber,
     pub extrinsic_index: u32,
     pub reporter: AccountId,
     pub owner: AccountId

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -780,7 +780,6 @@ decl_module! {
             }
             
             // 13. Emit work report event   
-            Self::deposit_event(RawEvent::QueueWorkReportSuccess(<system::Module<T>>::block_number(), extrinsic_index, reporter.clone(), owner.clone()));
             Self::deposit_event(RawEvent::WorksReportSuccess(reporter.clone(), curr_pk.clone()));
 
             // 14. Try to free count limitation
@@ -1561,12 +1560,11 @@ decl_event!(
         QueueWorkReportSuccess(SworkerAnchor, AccountId, AccountId),
         /// Set the crust-spower service superior account.
         SetSpowerSuperiorSuccess(AccountId),
+        /// Update spower success
         /// The first item is the account who update the spower.
         /// The second item is the current block number
         /// The third item is the updated sworkers count for sworker::WorkReports
         /// The fourth item is the updated files count for market::FilesV2
-        /// The fifth item is the processed update blocks count for market::UpdatedFilesToProcess
-        /// The sixth item is the latest LastSpowerUpdateBlock value
-        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32, u32, BlockNumber),
+        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32),
     }
 );

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -71,7 +71,7 @@ pub trait WeightInfo {
     fn set_code() -> Weight;
     fn register() -> Weight;
     fn report_works(added: u32, deleted: u32) -> Weight;
-    fn update_spower(changed_sworkers_count: u32, changed_files_count: u32, changed_blocks_count: u32) -> Weight;
+    fn update_spower(changed_sworkers_count: u32, changed_files_count: u32) -> Weight;
     fn create_group() -> Weight;
     fn join_group() -> Weight;
     fn quit_group() -> Weight;
@@ -185,6 +185,22 @@ impl<T: Config> SworkerInterface<T::AccountId> for Module<T> {
         LastProcessedBlockWorkReports::put(last_processed_block);
     }
     
+    // Update changed spower of sworkers
+	fn update_sworkers_changed_spower(sworker_spower_changed_map: &BTreeMap<SworkerAnchor, i64>) {
+        for (anchor, changed_spower) in sworker_spower_changed_map {
+            WorkReports::mutate_exists(anchor, |maybe_wr| match *maybe_wr {
+                Some(WorkReport { ref mut spower, .. }) => {
+                    if *changed_spower >= 0 {
+                        *spower = spower.saturating_add(changed_spower.abs() as u64);
+                    } else {
+                        *spower = spower.saturating_sub(changed_spower.abs() as u64);
+                    }                        
+                },
+                ref mut i => *i = None,
+            });
+        }
+    }
+
     // Update illegal file replicas count
     fn update_illegal_file_replicas_count(illegal_file_replicas_map: &BTreeMap<ReportSlot, u32>) {
         // For those legacy report slots, we just ignore them because 'AddedFilesCount' is reset per report slot
@@ -359,11 +375,7 @@ decl_error! {
         /// The spower superior account is not set. Please call the set_spower_superior extrinsic first.
         SpowerSuperiorNotSet,
         /// The caller account is not the spower superior account. Please check the caller account again.
-        IllegalSpowerSuperior,
-        /// Update spower call request arguments are invalid.
-        InvalidSpowerUpdateRequest,
-        /// Expired spower update blocks. This may be caused by the update_spower call replay.
-        ExpiredSpowerUpdateBlock
+        IllegalSpowerSuperior
     }
 }
 
@@ -781,12 +793,17 @@ decl_module! {
         }
 
         /// Update sworker spower, which is called by Crust-Spower service
-        #[weight = T::WeightInfo::update_spower(sworker_changed_spower_map.len() as u32, file_new_spower_map.len() as u32, updated_blocks.len() as u32)]
+        /// Arguments:
+        /// sworker_changed_spower_map: 
+        ///     The key is sworker anchor, the value is changed spower
+        /// files_changed_map:
+        ///     The map contains the files changed spower data, the data structure is
+        ///     Map<cid, (file_size, Map<owner, (who, anchor, created_at)>)>
+        #[weight = T::WeightInfo::update_spower(sworker_changed_spower_map.len() as u32, files_changed_map.len() as u32)]
         pub fn update_spower(
             origin,
             sworker_changed_spower_map: BTreeMap<SworkerAnchor, i64>,
-            file_new_spower_map: BTreeMap<MerkleRoot, u64>,
-            updated_blocks: Vec<BlockNumber>,
+            files_changed_map: BTreeMap<MerkleRoot, (u64, BTreeMap<T::AccountId, (T::AccountId, SworkerAnchor, Option<BlockNumber>)>)>,
         ) -> DispatchResult {
             let caller = ensure_signed(origin)?;
             let maybe_superior = Self::spower_superior();
@@ -795,14 +812,7 @@ decl_module! {
             ensure!(maybe_superior.is_some(), Error::<T>::SpowerSuperiorNotSet);
             ensure!(Some(&caller) == maybe_superior.as_ref(), Error::<T>::IllegalSpowerSuperior);
 
-            // 2. Check the LastSpowerUpdateBlock
-            ensure!(updated_blocks.len() > 0, Error::<T>::InvalidSpowerUpdateRequest);
-            let last_update_block = Self::last_spower_update_block();
-            let min_updated_block = updated_blocks.iter().min().unwrap();
-            let max_updated_block = updated_blocks.iter().max().unwrap();
-            ensure!(*min_updated_block > last_update_block, Error::<T>::ExpiredSpowerUpdateBlock);
-
-            // 3. Update sworker spower
+            // 2. Update sworker spower
             for (anchor, changed_spower) in sworker_changed_spower_map.iter() {
                 WorkReports::mutate_exists(anchor, |maybe_wr| match *maybe_wr {
                     Some(WorkReport { ref mut spower, .. }) => {
@@ -816,22 +826,17 @@ decl_module! {
                 });
             }
 
-            // 4. Update the file new spower in pallet_market
-            T::MarketInterface::update_file_spower(&file_new_spower_map);
-            
-            // 5. Clear the successfully processed files by blocks in pallet_market
-            T::MarketInterface::clear_processed_files_by_blocks(&updated_blocks);
+            // 3. Update the file new spower in pallet_market
+            T::MarketInterface::update_files_spower(&files_changed_map);
 
-            // 6. Set the LastSpowerUpdateBlock value, which is the latest block in updated_blocks
-            LastSpowerUpdateBlock::put(max_updated_block);
+            // 4. Set the LastSpowerUpdateBlock value, which is the latest block in updated_blocks
+            LastSpowerUpdateBlock::put(Self::get_current_block_number());
 
-            // 7. Emit the event
+            // 5. Emit the event
             Self::deposit_event(RawEvent::UpdateSpowerSuccess(caller, 
                 <system::Module<T>>::block_number(), 
                 sworker_changed_spower_map.len() as u32, 
-                file_new_spower_map.len() as u32,
-                updated_blocks.len() as u32,
-                (*max_updated_block as u64).try_into().ok().unwrap())); 
+                files_changed_map.len() as u32)); 
 
             // No charge fee?
             Ok(())
@@ -1576,8 +1581,6 @@ decl_event!(
         /// The second item is the current block number
         /// The third item is the updated sworkers count for sworker::WorkReports
         /// The fourth item is the updated files count for market::FilesV2
-        /// The fifth item is the processed update blocks count for market::UpdatedFilesToProcess
-        /// The sixth item is the latest LastSpowerUpdateBlock value
-        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32, u32, BlockNumber),
+        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32),
     }
 );

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -127,15 +127,6 @@ pub struct RegisterPayload<Public, AccountId> {
     public: Public
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct WorkReportMetadata<AccountId> {
-    pub report_block: BlockNumber,
-    pub extrinsic_index: u32,
-    pub reporter: AccountId,
-    pub owner: AccountId
-}
-
 /// An event handler for reporting works
 pub trait Works<AccountId> {
     fn report_works(workload_map: BTreeMap<AccountId, u128>, total_workload: u128) -> Weight;

--- a/cstrml/swork/src/lib.rs
+++ b/cstrml/swork/src/lib.rs
@@ -1561,11 +1561,12 @@ decl_event!(
         QueueWorkReportSuccess(SworkerAnchor, AccountId, AccountId),
         /// Set the crust-spower service superior account.
         SetSpowerSuperiorSuccess(AccountId),
-        /// Sworker spower update success
         /// The first item is the account who update the spower.
         /// The second item is the current block number
-        /// The third item is the updated sworkers count
-        /// The fourth item is the processed report blocks count for market::UpdatedFilesToProcess
-        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32),
+        /// The third item is the updated sworkers count for sworker::WorkReports
+        /// The fourth item is the updated files count for market::FilesV2
+        /// The fifth item is the processed update blocks count for market::UpdatedFilesToProcess
+        /// The sixth item is the latest LastSpowerUpdateBlock value
+        UpdateSpowerSuccess(AccountId, BlockNumber, u32, u32, u32, BlockNumber),
     }
 );

--- a/cstrml/swork/src/weight.rs
+++ b/cstrml/swork/src/weight.rs
@@ -50,6 +50,14 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight).saturating_mul(deleted as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight).saturating_mul(deleted as Weight))
 	}
+	fn update_spower(changed_sworkers_count: u32, changed_files_count: u32, changed_blocks_count: u32) -> Weight {
+		(100_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_files_count as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_files_count as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_blocks_count as Weight))
+	}
 	fn create_group() -> Weight {
 		(58_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(6 as Weight))

--- a/cstrml/swork/src/weight.rs
+++ b/cstrml/swork/src/weight.rs
@@ -50,13 +50,12 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight).saturating_mul(deleted as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight).saturating_mul(deleted as Weight))
 	}
-	fn update_spower(changed_sworkers_count: u32, changed_files_count: u32, changed_blocks_count: u32) -> Weight {
+	fn update_spower(changed_sworkers_count: u32, changed_files_count: u32) -> Weight {
 		(100_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_files_count as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_files_count as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_blocks_count as Weight))
 	}
 	fn create_group() -> Weight {
 		(58_000_000 as Weight)

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -70,7 +70,7 @@ pub mod swork {
     #[cfg(not(feature = "test"))]
     pub const REPORT_SLOT: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
 
-    pub const UPDATE_OFFSET: u32 = (REPORT_SLOT / 3) as u32;
+    pub const UPDATE_OFFSET: u32 = (REPORT_SLOT / 6) as u32;
     pub const END_OFFSET: u32 = 1;
 }
 

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -28,8 +28,8 @@ pub trait SworkerInterface<AccountId> {
 	fn get_added_files_count_and_clear_record() -> u32;
 	// Get owner of this member
 	fn get_owner(who: &AccountId) -> Option<AccountId>;
-	// Clear the designated processed work reports
-	fn clear_processed_work_reports(work_reports: &Vec<(SworkerAnchor, ReportSlot)>);
+	// Update the last processed block of work reports
+	fn update_last_processed_block_of_work_reports(last_processed_block: BlockNumber);
 	// Update illegal file replicas count
 	fn update_illegal_file_replicas_count(illegal_file_replicas_map: &BTreeMap<ReportSlot, u32>);
 }

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -2,7 +2,7 @@
 // This file is part of Crust.
 
 use frame_support::traits::{LockableCurrency, WithdrawReasons};
-use crate::{SworkerAnchor, MerkleRoot, BlockNumber, EraIndex};
+use crate::{SworkerAnchor, BlockNumber, EraIndex};
 use sp_runtime::{DispatchError, Perbill};
 
 /// A currency whose accounts can have liquidity restrictions.
@@ -30,12 +30,6 @@ pub trait SworkerInterface<AccountId> {
 
 /// Means for interacting with a specialized version of the `market` trait.
 pub trait MarketInterface<AccountId, Balance> {
-	// used for `added_files`
-	// return real spower of this file and whether this file is in the market system
-	fn upsert_replica(who: &AccountId, owner: AccountId, cid: &MerkleRoot, reported_file_size: u64, anchor: &SworkerAnchor, valid_at: BlockNumber) -> (u64, bool);
-	// used for `delete_files`
-	// return real spower of this file and whether this file is in the market system
-	fn delete_replica(who: &AccountId, owner: AccountId, cid: &MerkleRoot, anchor: &SworkerAnchor) -> (u64, bool);
 	// used for distribute market staking payout
 	fn withdraw_staking_pot() -> Balance;
 }

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -6,6 +6,7 @@ use crate::{BlockNumber, EraIndex, MerkleRoot, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::vec::Vec;
+use sp_std::collections::btree_map::BTreeMap;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait UsableCurrency<AccountId>: LockableCurrency<AccountId> {

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -6,7 +6,6 @@ use crate::{BlockNumber, EraIndex, MerkleRoot, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::vec::Vec;
-use sp_std::collections::btree_map::BTreeMap;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait UsableCurrency<AccountId>: LockableCurrency<AccountId> {

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -2,9 +2,10 @@
 // This file is part of Crust.
 
 use frame_support::traits::{LockableCurrency, WithdrawReasons};
-use crate::{BlockNumber, EraIndex, ReportSlot, SworkerAnchor};
+use crate::{BlockNumber, EraIndex, MerkleRoot, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
 use sp_std::vec::Vec;
+use sp_std::collections::btree_map::BTreeMap;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait UsableCurrency<AccountId>: LockableCurrency<AccountId> {
@@ -29,12 +30,18 @@ pub trait SworkerInterface<AccountId> {
 	fn get_owner(who: &AccountId) -> Option<AccountId>;
 	// Clear the designated processed work reports
 	fn clear_processed_work_reports(work_reports: &Vec<(SworkerAnchor, ReportSlot)>);
+	// Update illegal file replicas count
+	fn update_illegal_file_replicas_count(illegal_file_replicas_map: &BTreeMap<ReportSlot, u32>);
 }
 
 /// Means for interacting with a specialized version of the `market` trait.
 pub trait MarketInterface<AccountId, Balance> {
 	// used for distribute market staking payout
 	fn withdraw_staking_pot() -> Balance;
+	// Update file spower in market::FilesV2
+	fn update_file_spower(file_new_spower_map: &BTreeMap<MerkleRoot, u64>);
+	// Clear the successfully processed files by blocks in market::UpdatedFilesToProcessed
+	fn clear_processed_files_by_blocks(updated_blocks: &Vec<BlockNumber>);
 }
 
 pub trait BenefitInterface<AccountId, Balance, NegativeImbalance> {

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -5,6 +5,7 @@ use frame_support::traits::{LockableCurrency, WithdrawReasons};
 use crate::{BlockNumber, EraIndex, MerkleRoot, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
 use sp_std::collections::btree_map::BTreeMap;
+use sp_std::vec::Vec;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait UsableCurrency<AccountId>: LockableCurrency<AccountId> {
@@ -40,7 +41,7 @@ pub trait MarketInterface<AccountId, Balance> {
 	// used for distribute market staking payout
 	fn withdraw_staking_pot() -> Balance;
 	// Update files spower in market::FilesV2
-	fn update_files_spower(files_changed_map: &BTreeMap<MerkleRoot, (u64, BTreeMap<AccountId, (AccountId, SworkerAnchor, Option<BlockNumber>)>)>);
+	fn update_files_spower(changed_files: &Vec<(MerkleRoot, u64, Vec<(AccountId, AccountId, SworkerAnchor, Option<BlockNumber>)>)>);
 }
 
 pub trait BenefitInterface<AccountId, Balance, NegativeImbalance> {

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -40,7 +40,7 @@ pub trait MarketInterface<AccountId, Balance> {
 	fn withdraw_staking_pot() -> Balance;
 	// Update file spower in market::FilesV2
 	fn update_file_spower(file_new_spower_map: &BTreeMap<MerkleRoot, u64>);
-	// Clear the successfully processed files by blocks in market::UpdatedFilesToProcessed
+	// Clear the successfully processed files by blocks in market::UpdatedFilesToProcess
 	fn clear_processed_files_by_blocks(updated_blocks: &Vec<BlockNumber>);
 }
 

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -2,8 +2,9 @@
 // This file is part of Crust.
 
 use frame_support::traits::{LockableCurrency, WithdrawReasons};
-use crate::{SworkerAnchor, BlockNumber, EraIndex};
+use crate::{BlockNumber, EraIndex, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
+use sp_std::vec::Vec;
 
 /// A currency whose accounts can have liquidity restrictions.
 pub trait UsableCurrency<AccountId>: LockableCurrency<AccountId> {
@@ -26,6 +27,8 @@ pub trait SworkerInterface<AccountId> {
 	fn get_added_files_count_and_clear_record() -> u32;
 	// Get owner of this member
 	fn get_owner(who: &AccountId) -> Option<AccountId>;
+	// Clear the designated processed work reports
+	fn clear_processed_work_reports(work_reports: &Vec<(SworkerAnchor, ReportSlot)>);
 }
 
 /// Means for interacting with a specialized version of the `market` trait.

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -4,7 +4,6 @@
 use frame_support::traits::{LockableCurrency, WithdrawReasons};
 use crate::{BlockNumber, EraIndex, MerkleRoot, ReportSlot, SworkerAnchor};
 use sp_runtime::{DispatchError, Perbill};
-use sp_std::vec::Vec;
 use sp_std::collections::btree_map::BTreeMap;
 
 /// A currency whose accounts can have liquidity restrictions.
@@ -30,6 +29,8 @@ pub trait SworkerInterface<AccountId> {
 	fn get_owner(who: &AccountId) -> Option<AccountId>;
 	// Update the last processed block of work reports
 	fn update_last_processed_block_of_work_reports(last_processed_block: BlockNumber);
+	// Update changed spower of sworkers
+	fn update_sworkers_changed_spower(sworker_spower_changed_map: &BTreeMap<SworkerAnchor, i64>);
 	// Update illegal file replicas count
 	fn update_illegal_file_replicas_count(illegal_file_replicas_map: &BTreeMap<ReportSlot, u32>);
 }
@@ -38,10 +39,8 @@ pub trait SworkerInterface<AccountId> {
 pub trait MarketInterface<AccountId, Balance> {
 	// used for distribute market staking payout
 	fn withdraw_staking_pot() -> Balance;
-	// Update file spower in market::FilesV2
-	fn update_file_spower(file_new_spower_map: &BTreeMap<MerkleRoot, u64>);
-	// Clear the successfully processed files by blocks in market::UpdatedFilesToProcess
-	fn clear_processed_files_by_blocks(updated_blocks: &Vec<BlockNumber>);
+	// Update files spower in market::FilesV2
+	fn update_files_spower(files_changed_map: &BTreeMap<MerkleRoot, (u64, BTreeMap<AccountId, (AccountId, SworkerAnchor, Option<BlockNumber>)>)>);
 }
 
 pub trait BenefitInterface<AccountId, Balance, NegativeImbalance> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("crust"),
     impl_name: create_runtime_str!("crustio-crust"),
     authoring_version: 1,
-    spec_version: 22,
+    spec_version: 23,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("crust"),
     impl_name: create_runtime_str!("crustio-crust"),
     authoring_version: 1,
-    spec_version: 21,
+    spec_version: 22,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1


### PR DESCRIPTION
Implement the feature to support spower calculation offchain, this needs to work together with the crust-spower service [https://github.com/crustio/crust-spower](url).

Main changes:
1. swork::report_works doesn't invoke market::upsert_replicas and market::delete_replicas anymore.
2. The crust-spower service will index the work reports from chain, and aggregate multiple work reports, then call the newly added market::update_replicas extrinsic to update the replicas data in batch.
3. Update the market::calculate_rewards extrinsic to only liquidate, renew, or close file, but do not update replicas and spower anymore.
4. The crust-spower service will index the market::FilesV2 data from chain, and perform spower calculation for changed files in batch, then call the newly added swork::update_spower extrinsic to update the sworker spower and file spower.
5. The newly added market::update_replicas extrinsic and swork::update_spower extrinsic can only be called by specific register spower superior account, the account need to be set 
6. Unit tests have been updated per these changes.