### PR TITLE
Support calculate and update spower on chain.

### DIFF
--- a/cstrml/market/src/lib.rs
+++ b/cstrml/market/src/lib.rs
@@ -805,7 +805,7 @@ impl<T: Config> Module<T> {
 
                 let ReplicaToUpdate { reporter, owner, sworker_anchor, ..} = file_replica;
                 
-                let (is_replica_deleted, to_delete_spower) = Self::delete_replica(&mut file_info,&reporter, owner, &sworker_anchor);
+                let (is_replica_deleted, to_delete_spower) = Self::delete_replica(&mut file_info,&reporter, &owner, &sworker_anchor);
                 if is_replica_deleted {
                     // Update replicated sworker's changed spower
                     if let Some(changed_spower) = sworker_changed_spower_map.get_mut(sworker_anchor) {
@@ -817,7 +817,7 @@ impl<T: Config> Module<T> {
             }
 
             // Update the file info with all the above changes in one DB write
-            <FilesV2<T>>::insert(cid.clone(), file_info.clone());
+            <FilesV2<T>>::insert(cid, file_info);
             changed_files_count += 1;
         }
 

--- a/cstrml/market/src/weight.rs
+++ b/cstrml/market/src/weight.rs
@@ -49,7 +49,7 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 	}
 	fn update_replicas() -> Weight {
 		(1_000_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(500 as Weight))
-			.saturating_add(T::DbWeight::get().writes(500 as Weight))
+			.saturating_add(T::DbWeight::get().reads(1000 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1000 as Weight))
 	}
 }

--- a/cstrml/market/src/weight.rs
+++ b/cstrml/market/src/weight.rs
@@ -52,4 +52,11 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1000 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1000 as Weight))
 	}
+	fn calcuate_spowers(files_count: u32) -> Weight {
+		(1_000_000_000 as Weight)
+			.saturating_add((350_000_000 as Weight).saturating_mul(files_count as Weight))
+			.saturating_add((700_000_000 as Weight).saturating_mul(files_count as Weight))
+			.saturating_add(T::DbWeight::get().reads(2 as Weight).saturating_mul(files_count as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight).saturating_mul(files_count as Weight))
+	}
 }

--- a/cstrml/swork/benchmarking/src/lib.rs
+++ b/cstrml/swork/benchmarking/src/lib.rs
@@ -40,7 +40,7 @@ struct ReportWorksInfo {
 fn legal_work_report_with_srd() -> ReportWorksInfo {
     let curr_pk = vec![180,216,4,207,174,119,91,81,224,3,199,197,55,92,214,228,89,100,74,21,77,39,138,2,1,130,216,109,248,185,114,6,221,231,72,76,13,173,5,66,53,246,208,189,195,8,86,87,52,211,148,114,208,192,37,225,239,8,130,132,216,221,179,170];
     let prev_pk: Vec<u8> = vec![];
-    let block_number = 300;
+    let block_number = 0;
     let block_hash = vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
     let free: u64 = 4294967296;
     let spower: u64 = 0;
@@ -68,7 +68,7 @@ fn legal_work_report_with_srd() -> ReportWorksInfo {
 fn legal_work_report_with_added_files() -> ReportWorksInfo {
     let curr_pk = vec![180,216,4,207,174,119,91,81,224,3,199,197,55,92,214,228,89,100,74,21,77,39,138,2,1,130,216,109,248,185,114,6,221,231,72,76,13,173,5,66,53,246,208,189,195,8,86,87,52,211,148,114,208,192,37,225,239,8,130,132,216,221,179,170];
     let prev_pk: Vec<u8> = vec![];
-    let block_number = 300;
+    let block_number = 0;
     let block_hash = vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
     let free: u64 = 4294967296;
     let spower: u64 = 300;
@@ -234,7 +234,9 @@ benchmarks! {
         system::Module::<T>::set_block_number(303u32.into());
         let fake_bh:T::Hash = T::Hash::decode(&mut &wr.block_hash[..]).unwrap_or_default();
         let target_block_number:T::BlockNumber = 300u32.into();
+        let wr_block_number:T::BlockNumber = 0u32.into();
         <system::BlockHash<T>>::insert(target_block_number, fake_bh);
+        <system::BlockHash<T>>::insert(wr_block_number, fake_bh);
 
         // Prepare Files in market
         add_market_files::<T>(wr.added_files.clone(), caller.clone(), wr.curr_pk.clone());
@@ -272,7 +274,9 @@ benchmarks! {
         system::Module::<T>::set_block_number(303u32.into());
         let fake_bh:T::Hash = T::Hash::decode(&mut &wr.block_hash[..]).unwrap_or_default();
         let target_block_number:T::BlockNumber = 300u32.into();
+        let wr_block_number:T::BlockNumber = 0u32.into();
         <system::BlockHash<T>>::insert(target_block_number, fake_bh);
+        <system::BlockHash<T>>::insert(wr_block_number, fake_bh);
 
         // Prepare Files in market
         add_market_files::<T>(wr.added_files.clone(), caller.clone(), wr.curr_pk.clone());

--- a/cstrml/swork/src/weight.rs
+++ b/cstrml/swork/src/weight.rs
@@ -51,7 +51,9 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as Weight).saturating_mul(deleted as Weight))
 	}
 	fn update_spower(changed_sworkers_count: u32, changed_files_count: u32) -> Weight {
-		(100_000_000 as Weight)
+		(1_000_000_000 as Weight)
+			.saturating_add((350_000_000 as Weight).saturating_mul(changed_sworkers_count as Weight))
+			.saturating_add((700_000_000 as Weight).saturating_mul(changed_files_count as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight).saturating_mul(changed_sworkers_count as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight).saturating_mul(changed_files_count as Weight))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("crust"),
     impl_name: create_runtime_str!("crustio-crust"),
     authoring_version: 1,
-    spec_version: 23,
+    spec_version: 24,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1


### PR DESCRIPTION
1. Implement the market::calculate_spowers extrinsic
2. Increase weight for update_spower and update_replicas extrinsic to reflect proper resource assumption
3. Fix benchmark code
4. Some minor optimization to reduce memory usage